### PR TITLE
fix: post-PR5 review — SHA mismatch, dirty filter, tree dropdown, regex escape

### DIFF
--- a/components/studio/create-file-dialog.tsx
+++ b/components/studio/create-file-dialog.tsx
@@ -21,6 +21,11 @@ interface CreateFileDialogProps {
   onConfirm: (fileName: string, parentPath: string) => void
 }
 
+/** Escape special regex characters in a string for use in new RegExp() */
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+}
+
 export function CreateFileDialog({
   open,
   onOpenChange,
@@ -31,7 +36,7 @@ export function CreateFileDialog({
   const [fileName, setFileName] = React.useState("")
 
   // Strip contentRoot from display path
-  const displayPath = contentRoot ? parentPath.replace(new RegExp(`^${contentRoot}/?`), "") : parentPath
+  const displayPath = contentRoot ? parentPath.replace(new RegExp(`^${escapeRegex(contentRoot)}/?`), "") : parentPath
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
@@ -39,7 +44,7 @@ export function CreateFileDialog({
 
     // Auto-append .mdx if no extension provided
     let finalName = fileName.trim()
-    if (!finalName.match(/\.(mdx?|markdown|json)$/i)) {
+    if (!finalName.match(/\.(mdx?|markdown)$/i)) {
       finalName += ".mdx"
     }
 
@@ -69,7 +74,7 @@ export function CreateFileDialog({
               autoFocus
             />
             <p className="text-xs text-muted-foreground mt-1">
-              .mdx extension will be added automatically if not specified (or use .json, .md)
+              .mdx extension will be added automatically if not specified
             </p>
           </div>
           <DialogFooter>

--- a/components/studio/file-tree.tsx
+++ b/components/studio/file-tree.tsx
@@ -38,11 +38,11 @@ export function FileTree({
   )
 
   const topLevelFolders = React.useMemo(() => {
-    return displayTree
+    return tree
       .filter((node) => node.type === "dir")
       .map((node) => ({ name: node.name, path: node.path }))
       .sort((a, b) => a.name.localeCompare(b.name))
-  }, [displayTree])
+  }, [tree])
 
   const handleCreateClick = (path: string) => {
     if (onCreateFile) {

--- a/convex/documents.ts
+++ b/convex/documents.ts
@@ -402,7 +402,7 @@ export const listDirtyForProject = query({
       .query("documents")
       .withIndex("by_projectId_status", (q) => q.eq("projectId", args.projectId).eq("status", "approved"))
       .collect()
-    return [...drafts, ...approved].filter((d) => d.body != null)
+    return [...drafts, ...approved].filter((d) => d.body != null || d.frontmatter != null)
   },
 })
 

--- a/convex/githubWebhook.ts
+++ b/convex/githubWebhook.ts
@@ -86,9 +86,12 @@ export const handlePRMerged = mutation({
         // Already published -- skip (idempotent)
         if (doc.status === "published") continue
 
+        // Do NOT set githubSha here — mergeCommitSha is a git commit SHA,
+        // not a blob SHA. The correct blob SHAs were already stored by the
+        // publish-ops route before the PR was created. Storing a commit SHA
+        // would break conflict detection (which compares blob SHAs).
         await ctx.db.patch(doc._id, {
           status: "published",
-          githubSha: args.mergeCommitSha,
           lastSyncedAt: now,
           publishedAt: now,
           updatedAt: now,
@@ -111,7 +114,6 @@ export const handlePRMerged = mutation({
 
         await ctx.db.patch(doc._id, {
           status: "published",
-          githubSha: args.mergeCommitSha,
           lastSyncedAt: now,
           publishedAt: now,
           updatedAt: now,


### PR DESCRIPTION
## Summary

Code review of Tarun's commits in PR #5 revealed several bugs and edge cases:

- **githubSha stored as commit SHA** — `handlePRMerged` in the webhook handler was storing `mergeCommitSha` (a git commit SHA) into `githubSha` (which stores blob SHAs). This would cause conflict detection to always trigger after a PR merge, permanently blocking re-publishing of affected documents.
- **contentRoot not regex-escaped** — `CreateFileDialog` used `contentRoot` directly in `new RegExp()`. Folder names with dots, parens, or other regex metacharacters would throw `SyntaxError`.
- **`.json` files creatable but invisible** — The dialog allowed `.json` files, but `getContentTree()` only includes `.md/.mdx/.markdown`. Created `.json` files would vanish from the explorer after publish.
- **Create dropdown disappears during search** — `topLevelFolders` was derived from the search-filtered tree, so the folder dropdown disappeared when search narrowed results.
- **Frontmatter-only docs skipped on publish** — `listDirtyForProject` filtered `d.body != null`, silently excluding documents with only frontmatter and no body content.
- **Unused `framework` prop** — Passed to `CreateFileDialog` but never used.

## Test plan

- [ ] Create a file via the + dropdown while searching — dropdown should still show all folders
- [ ] Create a file in a project with a contentRoot containing dots (e.g., `apps/docs.content`)
- [ ] Save a document with only frontmatter (no body) — verify it appears in dirty docs count
- [ ] Publish changes via PR, merge PR — verify documents can be re-published without conflict errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)