### PR TITLE
feat(studio): always show JSX insert button

### DIFF
--- a/components/studio/insert-repo-component.tsx
+++ b/components/studio/insert-repo-component.tsx
@@ -10,14 +10,8 @@ import type { RepoComponentDef } from "@/lib/studio/component-registry"
 import { ComponentInsertModal } from "./component-insert-modal"
 import { useStudioAdapter } from "./studio-adapter-context"
 
-/** Feature flag: set NEXT_PUBLIC_COMPONENT_AUTHORING_V2=true to enable. */
-const COMPONENT_AUTHORING_V2 = process.env.NEXT_PUBLIC_COMPONENT_AUTHORING_V2 === "true"
-
 /**
  * Toolbar button that opens the component insert modal.
- *
- * Gated behind `NEXT_PUBLIC_COMPONENT_AUTHORING_V2` feature flag.
- * When the flag is off, the button is hidden entirely (safe rollback).
  *
  * In source mode, shows a message asking the user to switch to rich-text
  * mode (source-cursor insertion is deferred per plan).
@@ -76,9 +70,6 @@ export function InsertRepoComponent({
     },
     [insertJsx],
   )
-
-  // Feature flag gate: hide entirely when flag is off (safe rollback)
-  if (!COMPONENT_AUTHORING_V2) return null
 
   if (!hasComponents) return null
 


### PR DESCRIPTION
## Summary

- Remove the NEXT_PUBLIC_COMPONENT_AUTHORING_V2 feature flag gate from InsertRepoComponent.
- Make the JSX insert button always visible whenever the studio has any components registered.
- Keep the existing hasComponents guard so the button only appears when it can actually insert something.

## Rationale

The JSX authoring workflow is stable enough that we no longer need to hide it behind an environment flag. Showing the button by default simplifies configuration and avoids confusion when the flag is missing in .env.local.

## Implementation notes

- Dropped the COMPONENT_AUTHORING_V2 constant and the early return null guard in InsertRepoComponent.
- Left the hasComponents check intact to avoid rendering the button when there are no adapter/project components.
