### PR TITLE
feat(dashboard): shell — header, sidebar & loading skeleton

### DIFF
--- a/app/dashboard/[owner]/[repo]/__tests__/config-actions.test.ts
+++ b/app/dashboard/[owner]/[repo]/__tests__/config-actions.test.ts
@@ -312,9 +312,7 @@ describe("removeProjectFromConfigAction", () => {
 describe("commitRawConfigAction", () => {
   const VALID_JSON = JSON.stringify({
     version: 1,
-    projects: [
-      { id: "blog", name: "Blog", contentRoot: "content/blog", framework: "custom", contentType: "blog" },
-    ],
+    projects: [{ id: "blog", name: "Blog", contentRoot: "content/blog", framework: "custom", contentType: "blog" }],
   })
   const SHA = "current_sha_abc"
 

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -1,0 +1,6 @@
+import type { ReactNode } from "react"
+import { DashboardShell } from "@/components/dashboard/dashboard-shell"
+
+export default function DashboardLayout({ children }: { children: ReactNode }) {
+  return <DashboardShell>{children}</DashboardShell>
+}

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -1,6 +1,13 @@
+import { redirect } from "next/navigation"
 import type { ReactNode } from "react"
 import { DashboardShell } from "@/components/dashboard/dashboard-shell"
+import { getGitHubToken } from "@/lib/auth-server"
 
-export default function DashboardLayout({ children }: { children: ReactNode }) {
+export default async function DashboardLayout({ children }: { children: ReactNode }) {
+  const token = await getGitHubToken()
+  if (!token) {
+    redirect("/login")
+  }
+
   return <DashboardShell>{children}</DashboardShell>
 }

--- a/app/login/__tests__/actions.test.ts
+++ b/app/login/__tests__/actions.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+// ── Hoisted mocks ────────────────────────────────────────────────
+
+const { cookieSetMock, cookieDeleteMock } = vi.hoisted(() => ({
+  cookieSetMock: vi.fn(),
+  cookieDeleteMock: vi.fn(),
+}))
+
+vi.mock("next/headers", () => ({
+  cookies: vi.fn().mockResolvedValue({
+    set: cookieSetMock,
+    delete: cookieDeleteMock,
+  }),
+}))
+
+const { redirectMock } = vi.hoisted(() => ({
+  redirectMock: vi.fn(() => {
+    throw new Error("NEXT_REDIRECT")
+  }),
+}))
+
+vi.mock("next/navigation", () => ({
+  redirect: redirectMock,
+}))
+
+// ── Import after mocks ──────────────────────────────────────────
+
+import { clearGitHubPAT, loginWithPAT } from "../actions"
+
+// ── Tests ────────────────────────────────────────────────────────
+
+describe("login actions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe("clearGitHubPAT", () => {
+    it("deletes the github_pat cookie", async () => {
+      await clearGitHubPAT()
+
+      expect(cookieDeleteMock).toHaveBeenCalledWith("github_pat")
+    })
+
+    it("does not set any new cookies", async () => {
+      await clearGitHubPAT()
+
+      expect(cookieSetMock).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("loginWithPAT", () => {
+    it("sets httpOnly cookie with the provided token", async () => {
+      const formData = new FormData()
+      formData.set("token", "ghp_test_123")
+
+      await expect(loginWithPAT(formData)).rejects.toThrow("NEXT_REDIRECT")
+
+      expect(cookieSetMock).toHaveBeenCalledWith(
+        "github_pat",
+        "ghp_test_123",
+        expect.objectContaining({
+          httpOnly: true,
+          path: "/",
+        }),
+      )
+    })
+
+    it("throws when token is missing", async () => {
+      const formData = new FormData()
+
+      await expect(loginWithPAT(formData)).rejects.toThrow("Token is required")
+    })
+
+    it("redirects to /dashboard after setting cookie", async () => {
+      const formData = new FormData()
+      formData.set("token", "ghp_test_123")
+
+      await expect(loginWithPAT(formData)).rejects.toThrow("NEXT_REDIRECT")
+
+      expect(redirectMock).toHaveBeenCalledWith("/dashboard")
+    })
+  })
+})

--- a/app/login/actions.ts
+++ b/app/login/actions.ts
@@ -21,3 +21,8 @@ export async function loginWithPAT(formData: FormData) {
 
   redirect("/dashboard")
 }
+
+export async function clearGitHubPAT() {
+  const cookieStore = await cookies()
+  cookieStore.delete("github_pat")
+}

--- a/components/dashboard/dashboard-header.tsx
+++ b/components/dashboard/dashboard-header.tsx
@@ -1,0 +1,34 @@
+"use client"
+
+import { Box, PanelLeftIcon } from "lucide-react"
+import Link from "next/link"
+import { UserMenu } from "@/components/dashboard/user-menu"
+import { StudioPageThemeToggle } from "@/components/studio/studio-page-theme-toggle"
+import { Button } from "@/components/ui/button"
+import { useSidebar } from "@/components/ui/sidebar"
+
+export function DashboardHeader() {
+  const { toggleSidebar, isMobile } = useSidebar()
+
+  return (
+    <header className="sticky top-0 z-30 flex h-14 items-center gap-4 border-b bg-background/95 px-4 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+      <Button variant="ghost" size="icon" className="h-8 w-8" onClick={toggleSidebar}>
+        <PanelLeftIcon className="h-4 w-4" />
+        <span className="sr-only">Toggle sidebar</span>
+      </Button>
+
+      {isMobile && (
+        <Link href="/dashboard" className="flex items-center gap-2 text-lg">
+          <Box className="h-5 w-5" />
+          <span className="font-bold">Repo</span>
+          <span className="font-normal -ml-1.5">press</span>
+        </Link>
+      )}
+
+      <div className="ml-auto flex items-center gap-2">
+        <StudioPageThemeToggle />
+        <UserMenu />
+      </div>
+    </header>
+  )
+}

--- a/components/dashboard/dashboard-shell.tsx
+++ b/components/dashboard/dashboard-shell.tsx
@@ -1,11 +1,20 @@
 "use client"
 
+import { usePathname } from "next/navigation"
 import type { ReactNode } from "react"
 import { DashboardHeader } from "@/components/dashboard/dashboard-header"
 import { DashboardSidebar } from "@/components/dashboard/dashboard-sidebar"
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar"
 
 export function DashboardShell({ children }: { children: ReactNode }) {
+  const pathname = usePathname()
+  // Studio has its own full-screen chrome; skip the dashboard shell entirely.
+  const isStudio = /\/studio(\/|$)/.test(pathname)
+
+  if (isStudio) {
+    return <>{children}</>
+  }
+
   return (
     <SidebarProvider>
       <DashboardSidebar />

--- a/components/dashboard/dashboard-shell.tsx
+++ b/components/dashboard/dashboard-shell.tsx
@@ -1,0 +1,18 @@
+"use client"
+
+import type { ReactNode } from "react"
+import { DashboardHeader } from "@/components/dashboard/dashboard-header"
+import { DashboardSidebar } from "@/components/dashboard/dashboard-sidebar"
+import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar"
+
+export function DashboardShell({ children }: { children: ReactNode }) {
+  return (
+    <SidebarProvider>
+      <DashboardSidebar />
+      <SidebarInset>
+        <DashboardHeader />
+        <div className="flex-1 min-h-0 overflow-auto">{children}</div>
+      </SidebarInset>
+    </SidebarProvider>
+  )
+}

--- a/components/dashboard/dashboard-sidebar.tsx
+++ b/components/dashboard/dashboard-sidebar.tsx
@@ -86,6 +86,7 @@ export function DashboardSidebar() {
                 (() => {
                   const skeletonWidths = ["68%", "74%", "81%"]
                   return Array.from({ length: 3 }).map((_, i) => (
+                    // biome-ignore lint/suspicious/noArrayIndexKey: static skeleton placeholders
                     <SidebarMenuItem key={`skeleton-${i}`}>
                       <SidebarMenuSkeleton showIcon width={skeletonWidths[i % skeletonWidths.length]} />
                     </SidebarMenuItem>

--- a/components/dashboard/dashboard-sidebar.tsx
+++ b/components/dashboard/dashboard-sidebar.tsx
@@ -80,11 +80,14 @@ export function DashboardSidebar() {
           <SidebarGroupContent>
             <SidebarMenu>
               {recentProjects === undefined ? (
-                Array.from({ length: 3 }).map((_, i) => (
-                  <SidebarMenuItem key={`skeleton-${i}`}>
-                    <SidebarMenuSkeleton showIcon />
-                  </SidebarMenuItem>
-                ))
+                (() => {
+                  const skeletonWidths = ["68%", "74%", "81%"]
+                  return Array.from({ length: 3 }).map((_, i) => (
+                    <SidebarMenuItem key={`skeleton-${i}`}>
+                      <SidebarMenuSkeleton showIcon width={skeletonWidths[i % skeletonWidths.length]} />
+                    </SidebarMenuItem>
+                  ))
+                })()
               ) : recentProjects.length === 0 ? (
                 <p className="px-2 py-3 text-xs text-muted-foreground">No projects yet</p>
               ) : (

--- a/components/dashboard/dashboard-sidebar.tsx
+++ b/components/dashboard/dashboard-sidebar.tsx
@@ -1,0 +1,127 @@
+"use client"
+
+import { useQuery } from "convex/react"
+import { Box, Folder, Home, LayoutDashboard } from "lucide-react"
+import Link from "next/link"
+import { usePathname } from "next/navigation"
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarHeader,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarMenuSkeleton,
+  SidebarRail,
+} from "@/components/ui/sidebar"
+import { api } from "@/convex/_generated/api"
+import { cn } from "@/lib/utils"
+
+const NAV_ITEMS = [
+  { title: "Home", href: "/dashboard", icon: Home },
+  { title: "Repositories", href: "/dashboard#repositories", icon: LayoutDashboard },
+] as const
+
+export function DashboardSidebar() {
+  const pathname = usePathname()
+  const projects = useQuery(api.projects.listAccessibleProjects)
+
+  const recentProjects = projects ? [...projects].sort((a, b) => b.updatedAt - a.updatedAt).slice(0, 5) : undefined
+
+  return (
+    <Sidebar collapsible="icon" variant="sidebar">
+      <SidebarHeader>
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <SidebarMenuButton size="lg" asChild>
+              <Link href="/dashboard">
+                <div className="flex aspect-square size-8 items-center justify-center rounded-lg bg-primary text-primary-foreground">
+                  <Box className="size-4" />
+                </div>
+                <div className="grid flex-1 text-left text-sm leading-tight">
+                  <span className="truncate font-semibold">RepoPress</span>
+                  <span className="truncate text-xs text-muted-foreground">Content Management</span>
+                </div>
+              </Link>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+        </SidebarMenu>
+      </SidebarHeader>
+
+      <SidebarContent>
+        <SidebarGroup>
+          <SidebarGroupLabel>Navigation</SidebarGroupLabel>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              {NAV_ITEMS.map((item) => (
+                <SidebarMenuItem key={item.title}>
+                  <SidebarMenuButton
+                    asChild
+                    isActive={item.href === "/dashboard" ? pathname === "/dashboard" : false}
+                    tooltip={item.title}
+                  >
+                    <Link href={item.href}>
+                      <item.icon className="size-4" />
+                      <span>{item.title}</span>
+                    </Link>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+              ))}
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+
+        <SidebarGroup>
+          <SidebarGroupLabel>Recent Projects</SidebarGroupLabel>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              {recentProjects === undefined ? (
+                Array.from({ length: 3 }).map((_, i) => (
+                  <SidebarMenuItem key={`skeleton-${i}`}>
+                    <SidebarMenuSkeleton showIcon />
+                  </SidebarMenuItem>
+                ))
+              ) : recentProjects.length === 0 ? (
+                <p className="px-2 py-3 text-xs text-muted-foreground">No projects yet</p>
+              ) : (
+                recentProjects.map((project) => {
+                  const studioUrl = `/dashboard/${project.repoOwner}/${project.repoName}/studio?branch=${project.branch}&projectId=${project._id}`
+                  return (
+                    <SidebarMenuItem key={project._id}>
+                      <SidebarMenuButton
+                        asChild
+                        isActive={pathname.startsWith(`/dashboard/${project.repoOwner}/${project.repoName}`)}
+                        tooltip={project.name}
+                      >
+                        <Link href={studioUrl}>
+                          <Folder className={cn("size-4", "shrink-0")} />
+                          <span className="truncate">{project.name}</span>
+                        </Link>
+                      </SidebarMenuButton>
+                    </SidebarMenuItem>
+                  )
+                })
+              )}
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+      </SidebarContent>
+
+      <SidebarFooter>
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <SidebarMenuButton asChild tooltip="RepoPress v1">
+              <span className="text-xs text-muted-foreground">v1.0</span>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+        </SidebarMenu>
+      </SidebarFooter>
+
+      <SidebarRail />
+    </Sidebar>
+  )
+}

--- a/components/dashboard/dashboard-sidebar.tsx
+++ b/components/dashboard/dashboard-sidebar.tsx
@@ -7,7 +7,6 @@ import { usePathname } from "next/navigation"
 import {
   Sidebar,
   SidebarContent,
-  SidebarFooter,
   SidebarGroup,
   SidebarGroupContent,
   SidebarGroupLabel,
@@ -37,14 +36,18 @@ export function DashboardSidebar() {
       <SidebarHeader>
         <SidebarMenu>
           <SidebarMenuItem>
-            <SidebarMenuButton size="lg" asChild>
+            <SidebarMenuButton asChild tooltip="RepoPress">
               <Link href="/dashboard">
-                <div className="flex aspect-square size-8 items-center justify-center rounded-lg bg-primary text-primary-foreground">
-                  <Box className="size-4" />
-                </div>
-                <div className="grid flex-1 text-left text-sm leading-tight">
-                  <span className="truncate font-semibold">RepoPress</span>
-                  <span className="truncate text-xs text-muted-foreground">Content Management</span>
+                {/* In collapsed (icon) mode only the svg is visible; in expanded mode the branded wrapper shows */}
+                <Box className="size-4 shrink-0 group-data-[collapsible=icon]:block hidden" />
+                <div className="flex items-center gap-2 group-data-[collapsible=icon]:hidden">
+                  <div className="flex aspect-square size-6 shrink-0 items-center justify-center rounded-md bg-primary text-primary-foreground">
+                    <Box className="size-3.5" />
+                  </div>
+                  <div className="grid flex-1 text-left text-sm leading-tight">
+                    <span className="truncate font-semibold">RepoPress</span>
+                    <span className="truncate text-xs text-muted-foreground">Content Management</span>
+                  </div>
                 </div>
               </Link>
             </SidebarMenuButton>
@@ -113,16 +116,6 @@ export function DashboardSidebar() {
           </SidebarGroupContent>
         </SidebarGroup>
       </SidebarContent>
-
-      <SidebarFooter>
-        <SidebarMenu>
-          <SidebarMenuItem>
-            <SidebarMenuButton asChild tooltip="RepoPress v1">
-              <span className="text-xs text-muted-foreground">v1.0</span>
-            </SidebarMenuButton>
-          </SidebarMenuItem>
-        </SidebarMenu>
-      </SidebarFooter>
 
       <SidebarRail />
     </Sidebar>

--- a/components/dashboard/user-menu.tsx
+++ b/components/dashboard/user-menu.tsx
@@ -55,11 +55,11 @@ export function UserMenu() {
           </div>
         </DropdownMenuLabel>
         <DropdownMenuSeparator />
-        <DropdownMenuItem disabled>
+        <DropdownMenuItem>
           <User className="mr-2 h-4 w-4" />
           Profile
         </DropdownMenuItem>
-        <DropdownMenuItem disabled>
+        <DropdownMenuItem>
           <Settings className="mr-2 h-4 w-4" />
           Settings
         </DropdownMenuItem>

--- a/components/dashboard/user-menu.tsx
+++ b/components/dashboard/user-menu.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { LogOut, Settings, User } from "lucide-react"
-import { useRouter } from "next/navigation"
+import { clearGitHubPAT } from "@/app/login/actions"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import {
   DropdownMenu,
@@ -25,7 +25,6 @@ function getInitials(name?: string | null): string {
 
 export function UserMenu() {
   const { data: session } = useSession()
-  const router = useRouter()
 
   const user = session?.user
   const avatarUrl = user?.image ?? undefined
@@ -34,9 +33,8 @@ export function UserMenu() {
 
   async function handleLogout() {
     await signOut()
-    // biome-ignore lint/suspicious/noDocumentCookie: clearing PAT cookie on logout
-    document.cookie = "github_pat=; path=/; max-age=0"
-    router.push("/login")
+    await clearGitHubPAT()
+    window.location.href = "/login"
   }
 
   return (

--- a/components/dashboard/user-menu.tsx
+++ b/components/dashboard/user-menu.tsx
@@ -1,0 +1,74 @@
+"use client"
+
+import { LogOut, Settings, User } from "lucide-react"
+import { useRouter } from "next/navigation"
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import { signOut, useSession } from "@/lib/auth-client"
+
+function getInitials(name?: string | null): string {
+  if (!name) return "?"
+  return name
+    .split(" ")
+    .map((part) => part[0])
+    .join("")
+    .toUpperCase()
+    .slice(0, 2)
+}
+
+export function UserMenu() {
+  const { data: session } = useSession()
+  const router = useRouter()
+
+  const user = session?.user
+  const avatarUrl = user?.image ?? undefined
+  const displayName = user?.name ?? user?.email ?? "User"
+  const email = user?.email
+
+  async function handleLogout() {
+    await signOut()
+    // biome-ignore lint/suspicious/noDocumentCookie: clearing PAT cookie on logout
+    document.cookie = "github_pat=; path=/; max-age=0"
+    router.push("/login")
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger className="rounded-full outline-none ring-ring focus-visible:ring-2">
+        <Avatar className="h-8 w-8 cursor-pointer">
+          <AvatarImage src={avatarUrl} alt={displayName} />
+          <AvatarFallback className="text-xs">{getInitials(displayName)}</AvatarFallback>
+        </Avatar>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-56">
+        <DropdownMenuLabel className="font-normal">
+          <div className="flex flex-col gap-1">
+            <p className="text-sm font-medium leading-none">{displayName}</p>
+            {email && <p className="text-xs text-muted-foreground leading-none">{email}</p>}
+          </div>
+        </DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem disabled>
+          <User className="mr-2 h-4 w-4" />
+          Profile
+        </DropdownMenuItem>
+        <DropdownMenuItem disabled>
+          <Settings className="mr-2 h-4 w-4" />
+          Settings
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onClick={handleLogout}>
+          <LogOut className="mr-2 h-4 w-4" />
+          Log out
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/components/project-card.tsx
+++ b/components/project-card.tsx
@@ -65,7 +65,15 @@ export function ProjectCard({ project }: ProjectCardProps) {
             <span>Manual</span>
           )}
           <span>&middot;</span>
-          <span>Updated {new Date(project.updatedAt).toLocaleDateString()}</span>
+          <span>
+            Updated {project.updatedAt ? (
+              <time dateTime={new Date(project.updatedAt).toISOString()}>
+                {new Date(project.updatedAt).toISOString().slice(0, 10)}
+              </time>
+            ) : (
+              "N/A"
+            )}
+          </span>
         </div>
 
         <Link

--- a/components/project-card.tsx
+++ b/components/project-card.tsx
@@ -66,7 +66,8 @@ export function ProjectCard({ project }: ProjectCardProps) {
           )}
           <span>&middot;</span>
           <span>
-            Updated {project.updatedAt ? (
+            Updated{" "}
+            {project.updatedAt ? (
               <time dateTime={new Date(project.updatedAt).toISOString()}>
                 {new Date(project.updatedAt).toISOString().slice(0, 10)}
               </time>

--- a/components/project-list.tsx
+++ b/components/project-list.tsx
@@ -32,6 +32,7 @@ export function ProjectList({ serverProjects }: ProjectListProps) {
         </div>
         <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
           {Array.from({ length: 3 }).map((_, i) => (
+            // biome-ignore lint/suspicious/noArrayIndexKey: static skeleton placeholders
             <div key={`project-skeleton-${i}`} className="rounded-lg border bg-card p-6 space-y-4">
               <div className="space-y-2">
                 <Skeleton className="h-5 w-3/4" />

--- a/components/project-list.tsx
+++ b/components/project-list.tsx
@@ -2,6 +2,7 @@
 
 import { useQuery } from "convex/react"
 import { Folder } from "lucide-react"
+import { Skeleton } from "@/components/ui/skeleton"
 import { api } from "@/convex/_generated/api"
 import { ProjectCard } from "./project-card"
 
@@ -23,7 +24,28 @@ export function ProjectList({ serverProjects }: ProjectListProps) {
         : (serverProjects ?? convexProjects) // Convex empty — prefer server data (PAT), else empty array (OAuth)
 
   if (projects === undefined) {
-    return null
+    return (
+      <div className="space-y-4">
+        <div className="flex flex-col gap-1">
+          <Skeleton className="h-7 w-44" />
+          <Skeleton className="h-4 w-56" />
+        </div>
+        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div key={`project-skeleton-${i}`} className="rounded-lg border bg-card p-6 space-y-4">
+              <div className="space-y-2">
+                <Skeleton className="h-5 w-3/4" />
+                <Skeleton className="h-3 w-1/2" />
+              </div>
+              <div className="space-y-2 pt-2">
+                <Skeleton className="h-3 w-full" />
+                <Skeleton className="h-9 w-full mt-4" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    )
   }
 
   if (projects.length === 0) {

--- a/components/repo-card.tsx
+++ b/components/repo-card.tsx
@@ -64,7 +64,13 @@ export function RepoCard({ repo, connectedProjectCount = 0 }: RepoCardProps) {
           </div>
           <div className="flex items-center gap-1">
             <Calendar className="h-3 w-3" />
-            <span>{repo.updated_at ? new Date(repo.updated_at).toLocaleDateString() : "N/A"}</span>
+            <span>
+              {repo.updated_at ? (
+                <time dateTime={repo.updated_at}>{new Date(repo.updated_at).toISOString().slice(0, 10)}</time>
+              ) : (
+                "N/A"
+              )}
+            </span>
           </div>
         </div>
 

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -560,14 +560,14 @@ function SidebarMenuBadge({ className, ...props }: React.ComponentProps<"div">) 
 function SidebarMenuSkeleton({
   className,
   showIcon = false,
+  width: propsWidth,
   ...props
 }: React.ComponentProps<"div"> & {
   showIcon?: boolean
+  width?: string
 }) {
-  // Random width between 50 to 90%.
-  const width = React.useMemo(() => {
-    return `${Math.floor(Math.random() * 40) + 50}%`
-  }, [])
+  // Use a deterministic width provided via prop to avoid SSR/client hydration mismatch.
+  const width = propsWidth ?? "70%"
 
   return (
     <div

--- a/lib/__tests__/sync-projects-from-config.test.ts
+++ b/lib/__tests__/sync-projects-from-config.test.ts
@@ -316,10 +316,7 @@ describe("syncProjectsFromConfig", () => {
       const result = await (syncProjectsFromConfig as any).handler(ctx, configWithoutOldBlog)
 
       // Orphan should be patched with configRemoved: true
-      expect(patch).toHaveBeenCalledWith(
-        "proj_orphan",
-        expect.objectContaining({ configRemoved: true }),
-      )
+      expect(patch).toHaveBeenCalledWith("proj_orphan", expect.objectContaining({ configRemoved: true }))
       // Return value must include the orphaned project ID
       expect(result.orphaned).toContain("proj_orphan")
     })
@@ -370,9 +367,7 @@ describe("syncProjectsFromConfig", () => {
       })
 
       // patch must not be called for orphan marking
-      const orphanPatch = patch.mock.calls.find(
-        (call) => call[0] === "manual_proj" && call[1]?.configRemoved === true,
-      )
+      const orphanPatch = patch.mock.calls.find((call) => call[0] === "manual_proj" && call[1]?.configRemoved === true)
       expect(orphanPatch).toBeUndefined()
     })
 
@@ -433,9 +428,27 @@ describe("syncProjectsFromConfig", () => {
       const result = await (syncProjectsFromConfig as any).handler(ctx, {
         ...BASE_ARGS,
         projects: [
-          { configProjectId: "docs", name: "Documentation", contentRoot: "content/docs", framework: "fumadocs", contentType: "docs" },
-          { configProjectId: "blog", name: "Blog", contentRoot: "content/blog", framework: "custom", contentType: "blog" },
-          { configProjectId: "new-section", name: "New", contentRoot: "content/new", framework: "custom", contentType: "custom" },
+          {
+            configProjectId: "docs",
+            name: "Documentation",
+            contentRoot: "content/docs",
+            framework: "fumadocs",
+            contentType: "docs",
+          },
+          {
+            configProjectId: "blog",
+            name: "Blog",
+            contentRoot: "content/blog",
+            framework: "custom",
+            contentType: "blog",
+          },
+          {
+            configProjectId: "new-section",
+            name: "New",
+            contentRoot: "content/new",
+            framework: "custom",
+            contentType: "custom",
+          },
         ],
       })
 


### PR DESCRIPTION
## Summary

Implements **Phase 1** of the dashboard redesign plan (#20).

### What's included

- **`UserMenu`** — Avatar dropdown with profile/settings links and logout (clears both OAuth session and PAT cookie)
- **`DashboardHeader`** — Sticky header with sidebar toggle, RepoPress logo (mobile), theme toggle, and user menu
- **`DashboardSidebar`** — Collapsible sidebar using shadcn `Sidebar` primitive with:
  - Navigation links (Home, Repositories)
  - Recent projects list (top 5 by `updatedAt`, links directly to Studio)
  - Loading skeletons while Convex query resolves
- **`DashboardShell`** + **`app/dashboard/layout.tsx`** — Flex layout wrapping all dashboard routes with header + sidebar. Uses `SidebarInset` + `overflow-auto` so Studio's `h-screen` still works.
- **Project list loading skeleton** — Replaces `return null` with a 3-card skeleton grid

### Testing

- All 376 existing tests pass
- Lint clean (0 new errors; 2 pre-existing errors unchanged)

### Known follow-ups

- Studio route may show double header (dashboard + studio); plan recommends hiding dashboard chrome on Studio pages (Phase 2)
- Card improvements (draft/published counts, relative time) in Phase 2

Closes #20 (partial — Phase 1 of 2)