### PR TITLE
fix: batch orphan cleanup and getOrCreate zombie state fix

### DIFF
--- a/app/dashboard/[owner]/[repo]/__tests__/config-actions.test.ts
+++ b/app/dashboard/[owner]/[repo]/__tests__/config-actions.test.ts
@@ -170,7 +170,7 @@ describe("addProjectToConfigAction", () => {
       expect.stringContaining("Blog"),
     )
     expect(syncProjectsServerSideMock).toHaveBeenCalledWith(TOKEN, OWNER, REPO, BRANCH, USER_ID, {
-      clearTombstones: true,
+      restoredConfigProjectIds: ["blog"],
     })
   })
 
@@ -252,7 +252,7 @@ describe("addProjectToConfigAction", () => {
 
     expect(result.success).toBe(true)
     expect(syncProjectsServerSideMock).toHaveBeenCalledWith(TOKEN, OWNER, REPO, BRANCH, "pat_user_xyz", {
-      clearTombstones: true,
+      restoredConfigProjectIds: ["blog"],
     })
   })
 
@@ -296,9 +296,7 @@ describe("updateProjectInConfigAction", () => {
       "abc123sha",
       'chore(repopress): update project "docs"',
     )
-    expect(syncProjectsServerSideMock).toHaveBeenCalledWith(TOKEN, OWNER, REPO, BRANCH, USER_ID, {
-      clearTombstones: true,
-    })
+    expect(syncProjectsServerSideMock).toHaveBeenCalledWith(TOKEN, OWNER, REPO, BRANCH, USER_ID)
   })
 
   it("returns { success: false } when updateProject throws unknown id", async () => {
@@ -340,9 +338,7 @@ describe("removeProjectFromConfigAction", () => {
     // removeProject is called (config-writer logic)
     expect(removeProjectMock).toHaveBeenCalledWith(BASE_CONFIG, "docs")
     // Sync triggers orphan detection inside syncProjectsFromConfig
-    expect(syncProjectsServerSideMock).toHaveBeenCalledWith(TOKEN, OWNER, REPO, BRANCH, USER_ID, {
-      clearTombstones: true,
-    })
+    expect(syncProjectsServerSideMock).toHaveBeenCalledWith(TOKEN, OWNER, REPO, BRANCH, USER_ID)
     // Commit message includes the project id
     expect(commitConfigMock).toHaveBeenCalledWith(
       TOKEN,
@@ -399,9 +395,7 @@ describe("removeProjectFromConfigAction", () => {
     // No commit — nothing to change in the config
     expect(commitConfigMock).not.toHaveBeenCalled()
     // Sync MUST run so orphan detection in Convex flags the stale project
-    expect(syncProjectsServerSideMock).toHaveBeenCalledWith(TOKEN, OWNER, REPO, BRANCH, USER_ID, {
-      clearTombstones: true,
-    })
+    expect(syncProjectsServerSideMock).toHaveBeenCalledWith(TOKEN, OWNER, REPO, BRANCH, USER_ID)
   })
 
   it("succeeds without committing when configProjectId is absent from a non-empty config", async () => {
@@ -415,9 +409,7 @@ describe("removeProjectFromConfigAction", () => {
 
     expect(result.success).toBe(true)
     expect(commitConfigMock).not.toHaveBeenCalled()
-    expect(syncProjectsServerSideMock).toHaveBeenCalledWith(TOKEN, OWNER, REPO, BRANCH, USER_ID, {
-      clearTombstones: true,
-    })
+    expect(syncProjectsServerSideMock).toHaveBeenCalledWith(TOKEN, OWNER, REPO, BRANCH, USER_ID)
   })
 })
 
@@ -436,7 +428,7 @@ describe("commitRawConfigAction", () => {
   })
 
   it("parses, validates and commits a valid JSON config", async () => {
-    const result = await commitRawConfigAction(OWNER, REPO, BRANCH, VALID_JSON, SHA)
+    const result = await commitRawConfigAction(OWNER, REPO, BRANCH, VALID_JSON, SHA, JSON.stringify(BASE_CONFIG))
 
     expect(result.success).toBe(true)
     expect(commitConfigMock).toHaveBeenCalledWith(
@@ -449,12 +441,12 @@ describe("commitRawConfigAction", () => {
       "chore(repopress): update config via raw editor",
     )
     expect(syncProjectsServerSideMock).toHaveBeenCalledWith(TOKEN, OWNER, REPO, BRANCH, USER_ID, {
-      clearTombstones: true,
+      restoredConfigProjectIds: ["blog"],
     })
   })
 
   it("returns { success: false } for malformed JSON (not parseable)", async () => {
-    const result = await commitRawConfigAction(OWNER, REPO, BRANCH, "{not valid json", SHA)
+    const result = await commitRawConfigAction(OWNER, REPO, BRANCH, "{not valid json", SHA, JSON.stringify(BASE_CONFIG))
 
     expect(result).toEqual({ success: false, error: "Invalid JSON format" })
     expect(commitConfigMock).not.toHaveBeenCalled()
@@ -462,7 +454,14 @@ describe("commitRawConfigAction", () => {
 
   it("returns { success: false } when JSON parses but fails Zod schema", async () => {
     // Missing required 'version' and 'projects'
-    const result = await commitRawConfigAction(OWNER, REPO, BRANCH, JSON.stringify({ foo: "bar" }), SHA)
+    const result = await commitRawConfigAction(
+      OWNER,
+      REPO,
+      BRANCH,
+      JSON.stringify({ foo: "bar" }),
+      SHA,
+      JSON.stringify(BASE_CONFIG),
+    )
 
     expect(result.success).toBe(false)
     expect(result).toHaveProperty("error")
@@ -473,14 +472,21 @@ describe("commitRawConfigAction", () => {
   it("returns { success: false } when not authenticated", async () => {
     getGitHubTokenMock.mockResolvedValue(null)
 
-    const result = await commitRawConfigAction(OWNER, REPO, BRANCH, VALID_JSON, SHA)
+    const result = await commitRawConfigAction(OWNER, REPO, BRANCH, VALID_JSON, SHA, JSON.stringify(BASE_CONFIG))
 
     expect(result.success).toBe(false)
     expect(commitConfigMock).not.toHaveBeenCalled()
   })
 
   it("uses provided SHA (not re-fetched from GitHub) to avoid unnecessary round-trip", async () => {
-    const result = await commitRawConfigAction(OWNER, REPO, BRANCH, VALID_JSON, "explicit_sha_xyz")
+    const result = await commitRawConfigAction(
+      OWNER,
+      REPO,
+      BRANCH,
+      VALID_JSON,
+      "explicit_sha_xyz",
+      JSON.stringify(BASE_CONFIG),
+    )
 
     expect(result.success).toBe(true)
     expect(commitConfigMock).toHaveBeenCalledWith(

--- a/app/dashboard/[owner]/[repo]/__tests__/config-actions.test.ts
+++ b/app/dashboard/[owner]/[repo]/__tests__/config-actions.test.ts
@@ -81,6 +81,7 @@ vi.mock("@/convex/_generated/api", () => ({
       get: "projects:get",
       keepAsManual: "projects:keepAsManual",
       removeFull: "projects:removeFull",
+      removeAllOrphans: "projects:removeAllOrphans",
     },
   },
 }))
@@ -89,6 +90,7 @@ vi.mock("@/convex/_generated/api", () => ({
 
 import {
   addProjectToConfigAction,
+  cleanUpAllOrphansAction,
   commitRawConfigAction,
   deleteProjectPermanentlyAction,
   keepProjectAsManualAction,
@@ -525,5 +527,64 @@ describe("orphan resolution actions", () => {
       userId: "pat_user_xyz",
       projectAccessToken: "project-access-token",
     })
+  })
+})
+
+// ── cleanUpAllOrphansAction ───────────────────────────────────────────────────
+
+describe("cleanUpAllOrphansAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setupHappyPath()
+    convexMutationMock.mockResolvedValue({ removed: 2, remaining: 0 })
+  })
+
+  it("returns success with removed/remaining on the happy path", async () => {
+    const result = await cleanUpAllOrphansAction(OWNER, REPO)
+
+    expect(result).toEqual({ success: true, removed: 2, remaining: 0 })
+    expect(convexMutationMock).toHaveBeenCalledWith(
+      "projects:removeAllOrphans",
+      expect.objectContaining({
+        repoOwner: OWNER,
+        repoName: REPO,
+        actingUserId: USER_ID,
+        serverQueryToken: "server-query-token",
+      }),
+    )
+  })
+
+  it("returns { success: false } when not authenticated", async () => {
+    getGitHubTokenMock.mockResolvedValue(null)
+
+    const result = await cleanUpAllOrphansAction(OWNER, REPO)
+
+    expect(result).toEqual({ success: false, error: "Not authenticated with GitHub" })
+    expect(convexMutationMock).not.toHaveBeenCalled()
+  })
+
+  it("returns { success: false } when caller is not owner", async () => {
+    resolveRepoRoleMock.mockResolvedValue({ role: "editor", defaultBranch: "main", defaultBranchInferred: false })
+
+    const result = await cleanUpAllOrphansAction(OWNER, REPO)
+
+    expect(result).toEqual({ success: false, error: "Unauthorized: owner access required to remove all orphans" })
+    expect(convexMutationMock).not.toHaveBeenCalled()
+  })
+
+  it("surfaces remaining count when batch limit reached (>25 orphans)", async () => {
+    convexMutationMock.mockResolvedValue({ removed: 25, remaining: 7 })
+
+    const result = await cleanUpAllOrphansAction(OWNER, REPO)
+
+    expect(result).toEqual({ success: true, removed: 25, remaining: 7 })
+  })
+
+  it("returns { success: false } when the Convex mutation throws", async () => {
+    convexMutationMock.mockRejectedValue(new Error("Convex rate limit exceeded"))
+
+    const result = await cleanUpAllOrphansAction(OWNER, REPO)
+
+    expect(result).toEqual({ success: false, error: "Convex rate limit exceeded" })
   })
 })

--- a/app/dashboard/[owner]/[repo]/__tests__/config-actions.test.ts
+++ b/app/dashboard/[owner]/[repo]/__tests__/config-actions.test.ts
@@ -169,7 +169,9 @@ describe("addProjectToConfigAction", () => {
       "abc123sha",
       expect.stringContaining("Blog"),
     )
-    expect(syncProjectsServerSideMock).toHaveBeenCalledWith(TOKEN, OWNER, REPO, BRANCH, USER_ID)
+    expect(syncProjectsServerSideMock).toHaveBeenCalledWith(TOKEN, OWNER, REPO, BRANCH, USER_ID, {
+      clearTombstones: true,
+    })
   })
 
   it("returns { success: false } when not authenticated", async () => {
@@ -249,7 +251,9 @@ describe("addProjectToConfigAction", () => {
     })
 
     expect(result.success).toBe(true)
-    expect(syncProjectsServerSideMock).toHaveBeenCalledWith(TOKEN, OWNER, REPO, BRANCH, "pat_user_xyz")
+    expect(syncProjectsServerSideMock).toHaveBeenCalledWith(TOKEN, OWNER, REPO, BRANCH, "pat_user_xyz", {
+      clearTombstones: true,
+    })
   })
 
   it("returns { success: false } when both OAuth and PAT user resolution fail", async () => {
@@ -292,6 +296,9 @@ describe("updateProjectInConfigAction", () => {
       "abc123sha",
       'chore(repopress): update project "docs"',
     )
+    expect(syncProjectsServerSideMock).toHaveBeenCalledWith(TOKEN, OWNER, REPO, BRANCH, USER_ID, {
+      clearTombstones: true,
+    })
   })
 
   it("returns { success: false } when updateProject throws unknown id", async () => {
@@ -333,7 +340,9 @@ describe("removeProjectFromConfigAction", () => {
     // removeProject is called (config-writer logic)
     expect(removeProjectMock).toHaveBeenCalledWith(BASE_CONFIG, "docs")
     // Sync triggers orphan detection inside syncProjectsFromConfig
-    expect(syncProjectsServerSideMock).toHaveBeenCalledWith(TOKEN, OWNER, REPO, BRANCH, USER_ID)
+    expect(syncProjectsServerSideMock).toHaveBeenCalledWith(TOKEN, OWNER, REPO, BRANCH, USER_ID, {
+      clearTombstones: true,
+    })
     // Commit message includes the project id
     expect(commitConfigMock).toHaveBeenCalledWith(
       TOKEN,
@@ -390,7 +399,9 @@ describe("removeProjectFromConfigAction", () => {
     // No commit — nothing to change in the config
     expect(commitConfigMock).not.toHaveBeenCalled()
     // Sync MUST run so orphan detection in Convex flags the stale project
-    expect(syncProjectsServerSideMock).toHaveBeenCalledWith(TOKEN, OWNER, REPO, BRANCH, USER_ID)
+    expect(syncProjectsServerSideMock).toHaveBeenCalledWith(TOKEN, OWNER, REPO, BRANCH, USER_ID, {
+      clearTombstones: true,
+    })
   })
 
   it("succeeds without committing when configProjectId is absent from a non-empty config", async () => {
@@ -404,7 +415,9 @@ describe("removeProjectFromConfigAction", () => {
 
     expect(result.success).toBe(true)
     expect(commitConfigMock).not.toHaveBeenCalled()
-    expect(syncProjectsServerSideMock).toHaveBeenCalledWith(TOKEN, OWNER, REPO, BRANCH, USER_ID)
+    expect(syncProjectsServerSideMock).toHaveBeenCalledWith(TOKEN, OWNER, REPO, BRANCH, USER_ID, {
+      clearTombstones: true,
+    })
   })
 })
 
@@ -435,6 +448,9 @@ describe("commitRawConfigAction", () => {
       SHA,
       "chore(repopress): update config via raw editor",
     )
+    expect(syncProjectsServerSideMock).toHaveBeenCalledWith(TOKEN, OWNER, REPO, BRANCH, USER_ID, {
+      clearTombstones: true,
+    })
   })
 
   it("returns { success: false } for malformed JSON (not parseable)", async () => {

--- a/app/dashboard/[owner]/[repo]/config-actions.ts
+++ b/app/dashboard/[owner]/[repo]/config-actions.ts
@@ -50,6 +50,21 @@ async function fetchConfigOrThrow(token: string, owner: string, repo: string, br
   return { config: result.config, sha: result.sha }
 }
 
+function getAddedConfigProjectIds(previousIds: string[], nextIds: string[]) {
+  const existingIds = new Set(previousIds)
+  return nextIds.filter((id) => !existingIds.has(id))
+}
+
+function getConfigProjectIdsFromJson(rawJson: string) {
+  try {
+    const parsed = JSON.parse(rawJson) as { projects?: Array<{ id?: string }> }
+    if (!Array.isArray(parsed.projects)) return []
+    return parsed.projects.flatMap((project) => (typeof project.id === "string" ? [project.id] : []))
+  } catch {
+    return []
+  }
+}
+
 type ConfigActionResult =
   | { success: true; syncResult?: { synced: string[]; created: string[]; unchanged: string[] } }
   | { success: false; error: string }
@@ -155,7 +170,7 @@ export async function addProjectToConfigAction(
     )
 
     const syncResult = await syncProjectsServerSide(token, owner, repo, branch, actingUserId, {
-      clearTombstones: true,
+      restoredConfigProjectIds: [project.id],
     })
     revalidatePath(`/dashboard/${owner}/${repo}`)
     return { success: true, syncResult: syncResult ?? undefined }
@@ -190,9 +205,7 @@ export async function updateProjectInConfigAction(
       `chore(repopress): update project "${configProjectId}"`,
     )
 
-    const syncResult = await syncProjectsServerSide(token, owner, repo, branch, actingUserId, {
-      clearTombstones: true,
-    })
+    const syncResult = await syncProjectsServerSide(token, owner, repo, branch, actingUserId)
     revalidatePath(`/dashboard/${owner}/${repo}`)
     return { success: true, syncResult: syncResult ?? undefined }
   } catch (error: any) {
@@ -248,9 +261,7 @@ export async function removeProjectFromConfigAction(
     // removed (e.g. the config was manually cleared). The sync below will
     // trigger orphan detection and flag the Convex record appropriately.
 
-    const syncResult = await syncProjectsServerSide(token, owner, repo, branch, actingUserId, {
-      clearTombstones: true,
-    })
+    const syncResult = await syncProjectsServerSide(token, owner, repo, branch, actingUserId)
     revalidatePath(`/dashboard/${owner}/${repo}`)
     return { success: true, syncResult: syncResult ?? undefined }
   } catch (error: any) {
@@ -268,6 +279,7 @@ export async function commitRawConfigAction(
   branch: string,
   rawJson: string,
   currentSha: string,
+  previousJson: string,
 ): Promise<ConfigActionResult> {
   try {
     const { token, actingUserId } = await resolveAuthContext()
@@ -288,6 +300,11 @@ export async function commitRawConfigAction(
       return { success: false, error: `Validation failed: ${errors}` }
     }
 
+    const restoredConfigProjectIds = getAddedConfigProjectIds(
+      getConfigProjectIdsFromJson(previousJson),
+      validated.data.projects.map((project) => project.id),
+    )
+
     await commitConfig(
       token,
       owner,
@@ -298,9 +315,12 @@ export async function commitRawConfigAction(
       "chore(repopress): update config via raw editor",
     )
 
-    const syncResult = await syncProjectsServerSide(token, owner, repo, branch, actingUserId, {
-      clearTombstones: true,
-    })
+    const syncResult =
+      restoredConfigProjectIds.length > 0
+        ? await syncProjectsServerSide(token, owner, repo, branch, actingUserId, {
+            restoredConfigProjectIds,
+          })
+        : await syncProjectsServerSide(token, owner, repo, branch, actingUserId)
     revalidatePath(`/dashboard/${owner}/${repo}`)
     return { success: true, syncResult: syncResult ?? undefined }
   } catch (error: any) {

--- a/app/dashboard/[owner]/[repo]/config-actions.ts
+++ b/app/dashboard/[owner]/[repo]/config-actions.ts
@@ -154,7 +154,9 @@ export async function addProjectToConfigAction(
       `chore(repopress): add project "${project.name}"`,
     )
 
-    const syncResult = await syncProjectsServerSide(token, owner, repo, branch, actingUserId)
+    const syncResult = await syncProjectsServerSide(token, owner, repo, branch, actingUserId, {
+      clearTombstones: true,
+    })
     revalidatePath(`/dashboard/${owner}/${repo}`)
     return { success: true, syncResult: syncResult ?? undefined }
   } catch (error: any) {
@@ -188,7 +190,9 @@ export async function updateProjectInConfigAction(
       `chore(repopress): update project "${configProjectId}"`,
     )
 
-    const syncResult = await syncProjectsServerSide(token, owner, repo, branch, actingUserId)
+    const syncResult = await syncProjectsServerSide(token, owner, repo, branch, actingUserId, {
+      clearTombstones: true,
+    })
     revalidatePath(`/dashboard/${owner}/${repo}`)
     return { success: true, syncResult: syncResult ?? undefined }
   } catch (error: any) {
@@ -244,7 +248,9 @@ export async function removeProjectFromConfigAction(
     // removed (e.g. the config was manually cleared). The sync below will
     // trigger orphan detection and flag the Convex record appropriately.
 
-    const syncResult = await syncProjectsServerSide(token, owner, repo, branch, actingUserId)
+    const syncResult = await syncProjectsServerSide(token, owner, repo, branch, actingUserId, {
+      clearTombstones: true,
+    })
     revalidatePath(`/dashboard/${owner}/${repo}`)
     return { success: true, syncResult: syncResult ?? undefined }
   } catch (error: any) {
@@ -292,7 +298,9 @@ export async function commitRawConfigAction(
       "chore(repopress): update config via raw editor",
     )
 
-    const syncResult = await syncProjectsServerSide(token, owner, repo, branch, actingUserId)
+    const syncResult = await syncProjectsServerSide(token, owner, repo, branch, actingUserId, {
+      clearTombstones: true,
+    })
     revalidatePath(`/dashboard/${owner}/${repo}`)
     return { success: true, syncResult: syncResult ?? undefined }
   } catch (error: any) {

--- a/app/dashboard/[owner]/[repo]/config-actions.ts
+++ b/app/dashboard/[owner]/[repo]/config-actions.ts
@@ -337,3 +337,35 @@ export async function deleteProjectPermanentlyAction(
     return { success: false, error: error.message }
   }
 }
+
+/**
+ * Batch-removes all orphaned (configRemoved) projects for a repository.
+ * Requires owner-level access (consistent with per-project delete).
+ */
+export async function cleanUpAllOrphansAction(
+  owner: string,
+  repo: string,
+): Promise<{ success: true; removed: number; remaining: number } | { success: false; error: string }> {
+  try {
+    const { token, actingUserId } = await resolveAuthContext()
+
+    // Require owner role — consistent with deleteProjectPermanentlyAction
+    const { role } = await resolveRepoRole(token, owner, repo, actingUserId)
+    if (role !== "owner") {
+      throw new Error("Unauthorized: owner access required to remove all orphans")
+    }
+
+    const serverQueryToken = await mintServerQueryToken()
+    const result = await convex.mutation(api.projects.removeAllOrphans, {
+      actingUserId,
+      serverQueryToken,
+      repoOwner: owner,
+      repoName: repo,
+    })
+
+    revalidatePath(`/dashboard/${owner}/${repo}`)
+    return { success: true, removed: result.removed, remaining: result.remaining }
+  } catch (error: any) {
+    return { success: false, error: error.message }
+  }
+}

--- a/components/orphan-warning-card.tsx
+++ b/components/orphan-warning-card.tsx
@@ -1,12 +1,10 @@
 "use client"
 
 import { AlertTriangle, Hand, Loader2, Trash2 } from "lucide-react"
-import { useTransition } from "react"
+import { useState, useTransition } from "react"
 import { toast } from "sonner"
-import {
-  deleteProjectPermanentlyAction,
-  keepProjectAsManualAction,
-} from "@/app/dashboard/[owner]/[repo]/config-actions"
+import { keepProjectAsManualAction } from "@/app/dashboard/[owner]/[repo]/config-actions"
+import { DeleteProjectDialog } from "./delete-project-dialog"
 import { Alert, AlertDescription, AlertTitle } from "./ui/alert"
 import { Button } from "./ui/button"
 
@@ -25,8 +23,7 @@ interface OrphanWarningCardProps {
 
 export function OrphanWarningCard({ project, isOwner, onResolved }: OrphanWarningCardProps) {
   const [keepPending, startKeep] = useTransition()
-  const [deletePending, startDelete] = useTransition()
-  const isPending = keepPending || deletePending
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
 
   const handleKeep = () => {
     startKeep(async () => {
@@ -40,50 +37,44 @@ export function OrphanWarningCard({ project, isOwner, onResolved }: OrphanWarnin
     })
   }
 
-  const handleDelete = () => {
-    startDelete(async () => {
-      const result = await deleteProjectPermanentlyAction(project._id)
-      if (result.success) {
-        toast.success(`"${project.name}" deleted permanently`)
-        onResolved?.()
-      } else {
-        toast.error(result.error)
-      }
-    })
-  }
-
   return (
-    <Alert className="border-studio-attention/30 bg-studio-attention-muted/40">
-      <AlertTriangle className="h-4 w-4 text-studio-attention" />
-      <AlertTitle className="text-studio-attention text-sm font-medium">
-        &ldquo;{project.name}&rdquo; was removed from config
-      </AlertTitle>
-      <AlertDescription className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <div className="text-xs text-muted-foreground">
-          {project.contentRoot && <span className="font-medium">{project.contentRoot}</span>}
-          {project.configRemovedAt && <span> · Detected {new Date(project.configRemovedAt).toLocaleDateString()}</span>}
-        </div>
-        {isOwner && (
-          <div className="flex items-center gap-2 shrink-0">
-            <Button variant="outline" size="sm" onClick={handleKeep} disabled={isPending}>
-              {keepPending ? (
-                <Loader2 className="h-3.5 w-3.5 animate-spin mr-1" />
-              ) : (
-                <Hand className="h-3.5 w-3.5 mr-1" />
-              )}
-              Keep as Manual
-            </Button>
-            <Button variant="destructive" size="sm" onClick={handleDelete} disabled={isPending}>
-              {deletePending ? (
-                <Loader2 className="h-3.5 w-3.5 animate-spin mr-1" />
-              ) : (
-                <Trash2 className="h-3.5 w-3.5 mr-1" />
-              )}
-              Delete Permanently
-            </Button>
+    <>
+      <Alert className="border-studio-attention/30 bg-studio-attention-muted/40">
+        <AlertTriangle className="h-4 w-4 text-studio-attention" />
+        <AlertTitle className="text-studio-attention text-sm font-medium">
+          &ldquo;{project.name}&rdquo; was removed from config
+        </AlertTitle>
+        <AlertDescription className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="text-xs text-muted-foreground">
+            {project.contentRoot && <span className="font-medium">{project.contentRoot}</span>}
+            {project.configRemovedAt && (
+              <span> · Detected {new Date(project.configRemovedAt).toLocaleDateString()}</span>
+            )}
           </div>
-        )}
-      </AlertDescription>
-    </Alert>
+          {isOwner && (
+            <div className="flex items-center gap-2 shrink-0">
+              <Button variant="outline" size="sm" onClick={handleKeep} disabled={keepPending}>
+                {keepPending ? (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin mr-1" />
+                ) : (
+                  <Hand className="h-3.5 w-3.5 mr-1" />
+                )}
+                Keep as Manual
+              </Button>
+              <Button variant="destructive" size="sm" onClick={() => setDeleteDialogOpen(true)} disabled={keepPending}>
+                <Trash2 className="h-3.5 w-3.5 mr-1" />
+                Delete Permanently
+              </Button>
+            </div>
+          )}
+        </AlertDescription>
+      </Alert>
+      <DeleteProjectDialog
+        project={project}
+        open={deleteDialogOpen}
+        onOpenChange={setDeleteDialogOpen}
+        onSuccess={() => onResolved?.()}
+      />
+    </>
   )
 }

--- a/components/raw-config-editor.tsx
+++ b/components/raw-config-editor.tsx
@@ -100,7 +100,7 @@ export function RawConfigEditor({
     if (!validation.valid) return
 
     startTransition(async () => {
-      const result = await commitRawConfigAction(owner, repo, branch, value, sha)
+      const result = await commitRawConfigAction(owner, repo, branch, value, sha, initialJson)
       if (result.success) {
         toast.success("Config committed to GitHub")
         // Update SHA to prevent stale conflicts on subsequent edits

--- a/components/repo-project-hub.tsx
+++ b/components/repo-project-hub.tsx
@@ -21,6 +21,7 @@ import Link from "next/link"
 import { useRouter } from "next/navigation"
 import { useMemo, useState, useTransition } from "react"
 import { toast } from "sonner"
+import { cleanUpAllOrphansAction } from "@/app/dashboard/[owner]/[repo]/config-actions"
 import { retrySyncAction } from "@/lib/sync-projects"
 import { AddProjectDialog } from "./add-project-dialog"
 import { DeleteProjectDialog } from "./delete-project-dialog"
@@ -111,6 +112,26 @@ export function RepoProjectHub({
         router.refresh()
       } catch (err: any) {
         toast.error(err.message || "Failed to sync projects")
+      }
+    })
+  }
+
+  const handleCleanUpAll = () => {
+    startTransition(async () => {
+      try {
+        const result = await cleanUpAllOrphansAction(owner, repo)
+        if (result.success) {
+          const msg =
+            result.remaining > 0
+              ? `Queued cleanup for ${result.removed} orphaned project${result.removed !== 1 ? "s" : ""} (${result.remaining} remaining)`
+              : `Queued cleanup for ${result.removed} orphaned project${result.removed !== 1 ? "s" : ""}`
+          toast.success(msg)
+          router.refresh()
+        } else {
+          toast.error(result.error)
+        }
+      } catch (err: any) {
+        toast.error(err.message || "Failed to clean up orphans")
       }
     })
   }
@@ -223,6 +244,27 @@ export function RepoProjectHub({
       {/* Orphan warnings */}
       {orphanedProjects.length > 0 && (
         <div className="flex flex-col gap-3">
+          <div className="flex items-center justify-between">
+            <p className="text-sm font-medium text-studio-attention">
+              {orphanedProjects.length} project{orphanedProjects.length !== 1 ? "s" : ""} removed from config
+            </p>
+            {role === "owner" && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={handleCleanUpAll}
+                disabled={isPending}
+                className="text-destructive hover:text-destructive"
+              >
+                {isPending ? (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin mr-1" />
+                ) : (
+                  <Trash2 className="h-3.5 w-3.5 mr-1" />
+                )}
+                Remove All
+              </Button>
+            )}
+          </div>
           {orphanedProjects.map((project) => (
             <OrphanWarningCard
               key={project._id}

--- a/convex/projects.ts
+++ b/convex/projects.ts
@@ -408,13 +408,16 @@ export const getOrCreate = mutation({
   handler: async (ctx, args) => {
     await verifyCallerIdentity(ctx, args.userId)
 
-    const existing = await ctx.db
+    const matches = await ctx.db
       .query("projects")
       .withIndex("by_userId_repo", (q) =>
         q.eq("userId", args.userId).eq("repoOwner", args.repoOwner).eq("repoName", args.repoName),
       )
       .filter((q) => q.and(q.eq(q.field("branch"), args.branch), q.eq(q.field("contentRoot"), args.contentRoot)))
-      .first()
+      .collect()
+
+    // Prefer a live project when a previous match is still being deleted.
+    const existing = matches.find((project) => !project.name.startsWith("[DELETING]")) ?? matches[0]
 
     if (existing) {
       // Skip projects that are being deleted — treat as if they don't exist
@@ -482,6 +485,9 @@ export const syncProjectsFromConfig = mutation({
     // projects whose configProjectId is absent from that branch's config but
     // still present in the canonical branch config.
     runOrphanDetection: v.optional(v.boolean()),
+    // Explicit opt-in for config write flows that should resurrect a previously
+    // deleted config project when it is intentionally re-added.
+    clearTombstones: v.optional(v.boolean()),
     projects: v.array(
       v.object({
         configProjectId: v.string(),
@@ -542,16 +548,13 @@ export const syncProjectsFromConfig = mutation({
         .first()
 
       if (tombstone) {
-        // Studio auto-syncs (runOrphanDetection: false) run on every page load and may
-        // be triggered by non-owner users. They must NOT clear tombstones — doing so
-        // would silently resurrect a project the owner intentionally deleted.
-        // Only canonical syncs (runOrphanDetection not explicitly false) may clear
-        // tombstones, since those are deliberate user-initiated actions.
-        if (args.runOrphanDetection === false) {
+        // Default/read-time syncs must preserve tombstones so page loads cannot
+        // resurrect intentionally deleted config projects. Only explicit config
+        // write flows opt into clearing them, and never from Studio branch syncs.
+        if (!args.clearTombstones || args.runOrphanDetection === false) {
           continue
         }
-        // Re-adding a project to config is an explicit user intent to recreate it.
-        // Clear the tombstone so the project can be created fresh on this sync.
+
         await ctx.db.delete(tombstone._id)
       }
 

--- a/convex/projects.ts
+++ b/convex/projects.ts
@@ -1000,19 +1000,17 @@ export const removeAllOrphans = mutation({
     for (const orphan of batch) {
       // Insert tombstone only if one doesn't already exist (dedupe)
       if (orphan.frameworkSource === "config" && orphan.configProjectId) {
+        const configProjectId = orphan.configProjectId
         const existingTombstone = await ctx.db
           .query("deletedConfigProjects")
           .withIndex("by_repo_configProjectId", (q) =>
-            q
-              .eq("repoOwner", orphan.repoOwner)
-              .eq("repoName", orphan.repoName)
-              .eq("configProjectId", orphan.configProjectId),
+            q.eq("repoOwner", orphan.repoOwner).eq("repoName", orphan.repoName).eq("configProjectId", configProjectId),
           )
           .first()
 
         if (!existingTombstone) {
           await ctx.db.insert("deletedConfigProjects", {
-            configProjectId: orphan.configProjectId,
+            configProjectId,
             repoOwner: orphan.repoOwner,
             repoName: orphan.repoName,
             branch: orphan.branch,

--- a/convex/projects.ts
+++ b/convex/projects.ts
@@ -533,17 +533,26 @@ export const syncProjectsFromConfig = mutation({
     for (const p of args.projects) {
       const nextBranch = p.branch || args.branch
 
-      // Skip if this configProjectId was previously deleted
-      const isTombstoned = await ctx.db
+      // Check if this configProjectId was previously deleted
+      const tombstone = await ctx.db
         .query("deletedConfigProjects")
         .withIndex("by_repo_configProjectId", (q) =>
           q.eq("repoOwner", args.repoOwner).eq("repoName", args.repoName).eq("configProjectId", p.configProjectId),
         )
         .first()
 
-      if (isTombstoned) {
-        // Skip this project — it was intentionally deleted
-        continue
+      if (tombstone) {
+        // Studio auto-syncs (runOrphanDetection: false) run on every page load and may
+        // be triggered by non-owner users. They must NOT clear tombstones — doing so
+        // would silently resurrect a project the owner intentionally deleted.
+        // Only canonical syncs (runOrphanDetection not explicitly false) may clear
+        // tombstones, since those are deliberate user-initiated actions.
+        if (args.runOrphanDetection === false) {
+          continue
+        }
+        // Re-adding a project to config is an explicit user intent to recreate it.
+        // Clear the tombstone so the project can be created fresh on this sync.
+        await ctx.db.delete(tombstone._id)
       }
 
       // 1) Preferred match: explicit config project ID (across ALL projects for repo).

--- a/convex/projects.ts
+++ b/convex/projects.ts
@@ -417,6 +417,17 @@ export const getOrCreate = mutation({
       .first()
 
     if (existing) {
+      // Skip projects that are being deleted — treat as if they don't exist
+      if (existing.name.startsWith("[DELETING]")) {
+        const now = Date.now()
+        return await ctx.db.insert("projects", {
+          ...args,
+          createdBy: args.userId,
+          createdAt: now,
+          updatedAt: now,
+        })
+      }
+
       // Update framework/schema/components if re-detected values differ from stored ones
       const updates: Record<string, unknown> = {}
       if (args.detectedFramework && args.detectedFramework !== existing.detectedFramework) {
@@ -434,6 +445,10 @@ export const getOrCreate = mutation({
       if (args.components && JSON.stringify(args.components) !== JSON.stringify((existing as any).components)) {
         updates.components = args.components
       }
+      // Note: do NOT clear configRemoved here — orphan cleanup should happen
+      // through explicit user actions (Remove All, Keep as Manual, Delete Permanently).
+      // Clearing it silently would leave config-related fields (frameworkSource,
+      // configProjectId) intact, creating inconsistent state.
       if (Object.keys(updates).length > 0) {
         await ctx.db.patch(existing._id, { ...updates, updatedAt: Date.now() })
       }
@@ -831,6 +846,12 @@ export const _removeFullBatch = internalMutation({
       return
     }
 
+    // Safety: abort if project was un-orphaned (e.g. re-added to config) between
+    // scheduling and execution. Only proceed if still marked [DELETING].
+    if (!project.name.startsWith("[DELETING]")) {
+      return
+    }
+
     if (args.phase === "documents") {
       let deletesRemaining = MAX_DELETES_PER_INVOCATION
 
@@ -922,5 +943,84 @@ export const _removeFullBatch = internalMutation({
     }
 
     throw new Error(`Unknown cleanup phase: ${args.phase}`)
+  },
+})
+
+/**
+ * Batch-removes all orphaned (configRemoved) projects for a repository.
+ * Inserts tombstones and schedules two-phase deletion for each orphan.
+ * Auth: server query token ONLY — called from server action that verifies
+ * GitHub owner-level permissions. No direct OAuth fallback (destructive op).
+ * Processes at most MAX_ORPHANS_PER_BATCH to stay within Convex limits.
+ */
+export const removeAllOrphans = mutation({
+  args: {
+    actingUserId: v.string(),
+    serverQueryToken: v.string(),
+    repoOwner: v.string(),
+    repoName: v.string(),
+  },
+  handler: async (ctx, args) => {
+    // Auth: server query token only — no OAuth fallback for this destructive op
+    if (!(await verifyServerQueryToken(args.serverQueryToken))) {
+      throw new Error("Unauthorized: invalid server query token")
+    }
+
+    const callerUserId = args.actingUserId
+    const MAX_ORPHANS_PER_BATCH = 25
+
+    const repoProjects = await ctx.db
+      .query("projects")
+      .withIndex("by_repo", (q) => q.eq("repoOwner", args.repoOwner).eq("repoName", args.repoName))
+      .collect()
+
+    const orphans = repoProjects.filter((p) => p.configRemoved && !p.name.startsWith("[DELETING]"))
+
+    if (orphans.length === 0) {
+      return { removed: 0, remaining: 0 }
+    }
+
+    const batch = orphans.slice(0, MAX_ORPHANS_PER_BATCH)
+    const now = Date.now()
+
+    for (const orphan of batch) {
+      // Insert tombstone only if one doesn't already exist (dedupe)
+      if (orphan.frameworkSource === "config" && orphan.configProjectId) {
+        const existingTombstone = await ctx.db
+          .query("deletedConfigProjects")
+          .withIndex("by_repo_configProjectId", (q) =>
+            q
+              .eq("repoOwner", orphan.repoOwner)
+              .eq("repoName", orphan.repoName)
+              .eq("configProjectId", orphan.configProjectId),
+          )
+          .first()
+
+        if (!existingTombstone) {
+          await ctx.db.insert("deletedConfigProjects", {
+            configProjectId: orphan.configProjectId,
+            repoOwner: orphan.repoOwner,
+            repoName: orphan.repoName,
+            branch: orphan.branch,
+            deletedBy: callerUserId,
+            deletedAt: now,
+          })
+        }
+      }
+
+      // Mark as deleting and schedule batch cleanup
+      await ctx.db.patch(orphan._id, {
+        name: `[DELETING] ${orphan.name}`,
+        updatedAt: now,
+      })
+
+      await ctx.scheduler.runAfter(0, internal.projects._removeFullBatch, {
+        projectId: orphan._id,
+        phase: "documents",
+      })
+    }
+
+    const remaining = orphans.length - batch.length
+    return { removed: batch.length, remaining }
   },
 })

--- a/convex/projects.ts
+++ b/convex/projects.ts
@@ -485,9 +485,9 @@ export const syncProjectsFromConfig = mutation({
     // projects whose configProjectId is absent from that branch's config but
     // still present in the canonical branch config.
     runOrphanDetection: v.optional(v.boolean()),
-    // Explicit opt-in for config write flows that should resurrect a previously
-    // deleted config project when it is intentionally re-added.
-    clearTombstones: v.optional(v.boolean()),
+    // Config project IDs that were intentionally restored by the current write.
+    // Only these IDs may clear a tombstone during sync.
+    restoredConfigProjectIds: v.optional(v.array(v.string())),
     projects: v.array(
       v.object({
         configProjectId: v.string(),
@@ -529,6 +529,7 @@ export const syncProjectsFromConfig = mutation({
     const synced: string[] = []
     const created: string[] = []
     const unchanged: string[] = []
+    const restoredConfigProjectIds = new Set(args.restoredConfigProjectIds ?? [])
 
     // Repo-scoped lookup: find ALL projects for this repo, regardless of creator
     const repoProjects = await ctx.db
@@ -549,9 +550,10 @@ export const syncProjectsFromConfig = mutation({
 
       if (tombstone) {
         // Default/read-time syncs must preserve tombstones so page loads cannot
-        // resurrect intentionally deleted config projects. Only explicit config
-        // write flows opt into clearing them, and never from Studio branch syncs.
-        if (!args.clearTombstones || args.runOrphanDetection === false) {
+        // resurrect intentionally deleted config projects. Only explicit
+        // re-adds of the same configProjectId may clear a tombstone, and never
+        // from Studio branch syncs.
+        if (args.runOrphanDetection === false || !restoredConfigProjectIds.has(p.configProjectId)) {
           continue
         }
 

--- a/lib/__tests__/sync-projects-from-config.test.ts
+++ b/lib/__tests__/sync-projects-from-config.test.ts
@@ -33,7 +33,7 @@ vi.mock("@/lib/project-access-token", () => ({
 
 // ── Import after mocks ───────────────────────────────────────────────────────
 
-import { syncProjectsFromConfig } from "@/convex/projects"
+import { getOrCreate, removeAllOrphans, syncProjectsFromConfig } from "@/convex/projects"
 
 // ── Shared helpers ───────────────────────────────────────────────────────────
 
@@ -508,5 +508,270 @@ describe("syncProjectsFromConfig", () => {
       expect(result.synced).toContain("proj_out")
       expect(result.created).toContain("new_id")
     })
+  })
+})
+
+// ── getOrCreate tests ─────────────────────────────────────────────────────────
+
+describe("getOrCreate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    safeGetAuthUserMock.mockResolvedValue({ _id: "user_owner" })
+  })
+
+  function createGetOrCreateCtx({
+    existingProject = null as ProjectRow | null,
+    patch = vi.fn(),
+    insert = vi.fn().mockResolvedValue("new_project_id"),
+  } = {}) {
+    return {
+      db: {
+        get: vi.fn(),
+        patch,
+        insert,
+        delete: vi.fn(),
+        query: vi.fn((_table: string) => ({
+          withIndex: (_index: string, _fn: unknown) => ({
+            filter: (_filterFn: unknown) => ({
+              first: vi.fn().mockResolvedValue(existingProject),
+            }),
+          }),
+        })),
+      },
+      scheduler: { runAfter: vi.fn() },
+    } as any
+  }
+
+  const GET_OR_CREATE_ARGS = {
+    userId: "user_owner",
+    repoOwner: "acme",
+    repoName: "docs",
+    branch: "main",
+    contentRoot: "content/docs",
+    name: "Docs",
+    contentType: "docs" as const,
+  }
+
+  it("does NOT clear configRemoved flag (orphan cleanup is explicit)", async () => {
+    const orphanedProject = makeProject({
+      _id: "proj_orphan",
+      configRemoved: true,
+      configRemovedAt: 1000000,
+    })
+    const patch = vi.fn()
+    const ctx = createGetOrCreateCtx({ existingProject: orphanedProject, patch })
+
+    const result = await (getOrCreate as any).handler(ctx, GET_OR_CREATE_ARGS)
+
+    expect(result).toBe("proj_orphan")
+    // Should NOT patch to clear configRemoved — orphan cleanup is explicit
+    expect(patch).not.toHaveBeenCalled()
+  })
+
+  it("creates a new project when existing project is [DELETING]", async () => {
+    const deletingProject = makeProject({
+      _id: "proj_deleting",
+      name: "[DELETING] Old Blog",
+    })
+    const patch = vi.fn()
+    const insert = vi.fn().mockResolvedValue("new_proj_id")
+    const ctx = createGetOrCreateCtx({ existingProject: deletingProject, patch, insert })
+
+    const result = await (getOrCreate as any).handler(ctx, GET_OR_CREATE_ARGS)
+
+    expect(result).toBe("new_proj_id")
+    // Should NOT patch the deleting project
+    expect(patch).not.toHaveBeenCalled()
+    // Should insert a fresh project
+    expect(insert).toHaveBeenCalledWith(
+      "projects",
+      expect.objectContaining({
+        repoOwner: GET_OR_CREATE_ARGS.repoOwner,
+        repoName: GET_OR_CREATE_ARGS.repoName,
+      }),
+    )
+  })
+
+  it("does NOT clear configRemoved when project is not orphaned", async () => {
+    const normalProject = makeProject({
+      _id: "proj_normal",
+      configRemoved: undefined,
+    })
+    const patch = vi.fn()
+    const ctx = createGetOrCreateCtx({ existingProject: normalProject, patch })
+
+    const result = await (getOrCreate as any).handler(ctx, GET_OR_CREATE_ARGS)
+
+    expect(result).toBe("proj_normal")
+    // No patch should be called since nothing changed
+    expect(patch).not.toHaveBeenCalled()
+  })
+})
+
+// ── removeAllOrphans tests ────────────────────────────────────────────────────
+
+describe("removeAllOrphans", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    safeGetAuthUserMock.mockResolvedValue(null)
+    verifyServerQueryTokenMock.mockResolvedValue(true)
+  })
+
+  function createRemoveCtx({
+    repoProjects = [] as ProjectRow[],
+    patch = vi.fn(),
+    insert = vi.fn().mockResolvedValue("tombstone_id"),
+    existingTombstone = null as any,
+  } = {}) {
+    return {
+      db: {
+        get: vi.fn(),
+        patch,
+        insert,
+        delete: vi.fn(),
+        query: vi.fn((table: string) => ({
+          withIndex: (_index: string, _fn: unknown) => ({
+            collect: vi.fn().mockResolvedValue(table === "projects" ? repoProjects : []),
+            first: vi.fn().mockResolvedValue(table === "deletedConfigProjects" ? existingTombstone : null),
+          }),
+        })),
+      },
+      scheduler: { runAfter: vi.fn() },
+    } as any
+  }
+
+  const REMOVE_ARGS = {
+    serverQueryToken: "valid_server_token",
+    actingUserId: "user_owner",
+    repoOwner: "acme",
+    repoName: "docs",
+  }
+
+  it("removes all orphaned projects and inserts tombstones", async () => {
+    const orphan1 = makeProject({
+      _id: "orphan_1",
+      configProjectId: "old-blog",
+      frameworkSource: "config",
+      configRemoved: true,
+      name: "Old Blog",
+    })
+    const orphan2 = makeProject({
+      _id: "orphan_2",
+      configProjectId: "old-docs",
+      frameworkSource: "config",
+      configRemoved: true,
+      name: "Old Docs",
+    })
+    const active = makeProject({
+      _id: "active_proj",
+      configProjectId: "docs",
+      frameworkSource: "config",
+      configRemoved: undefined,
+      name: "Docs",
+    })
+
+    const patch = vi.fn()
+    const insert = vi.fn().mockResolvedValue("tombstone_id")
+    const ctx = createRemoveCtx({ repoProjects: [orphan1, orphan2, active], patch, insert })
+
+    const result = await (removeAllOrphans as any).handler(ctx, REMOVE_ARGS)
+
+    expect(result.removed).toBe(2)
+    expect(result.remaining).toBe(0)
+
+    // Should insert 2 tombstones
+    const tombstoneInserts = insert.mock.calls.filter((c: any) => c[0] === "deletedConfigProjects")
+    expect(tombstoneInserts).toHaveLength(2)
+
+    // Should mark both as deleting
+    expect(patch).toHaveBeenCalledWith("orphan_1", expect.objectContaining({ name: "[DELETING] Old Blog" }))
+    expect(patch).toHaveBeenCalledWith("orphan_2", expect.objectContaining({ name: "[DELETING] Old Docs" }))
+
+    // Should schedule batch cleanup for each
+    expect(ctx.scheduler.runAfter).toHaveBeenCalledTimes(2)
+  })
+
+  it("returns removed: 0 when no orphans exist", async () => {
+    const active = makeProject({
+      _id: "active_proj",
+      configProjectId: "docs",
+      frameworkSource: "config",
+      configRemoved: undefined,
+      name: "Docs",
+    })
+
+    const ctx = createRemoveCtx({ repoProjects: [active] })
+
+    const result = await (removeAllOrphans as any).handler(ctx, REMOVE_ARGS)
+
+    expect(result.removed).toBe(0)
+    expect(result.remaining).toBe(0)
+    expect(ctx.scheduler.runAfter).not.toHaveBeenCalled()
+  })
+
+  it("skips projects already being deleted", async () => {
+    const orphanDeleting = makeProject({
+      _id: "orphan_deleting",
+      configProjectId: "old-blog",
+      frameworkSource: "config",
+      configRemoved: true,
+      name: "[DELETING] Old Blog",
+    })
+
+    const ctx = createRemoveCtx({ repoProjects: [orphanDeleting] })
+
+    const result = await (removeAllOrphans as any).handler(ctx, REMOVE_ARGS)
+
+    expect(result.removed).toBe(0)
+  })
+
+  it("rejects when server query token is invalid", async () => {
+    verifyServerQueryTokenMock.mockResolvedValue(false)
+    const ctx = createRemoveCtx()
+
+    await expect((removeAllOrphans as any).handler(ctx, REMOVE_ARGS)).rejects.toThrow(
+      "Unauthorized: invalid server query token",
+    )
+  })
+
+  it("skips tombstone for non-config orphans", async () => {
+    const orphanManual = makeProject({
+      _id: "orphan_manual",
+      frameworkSource: undefined,
+      configProjectId: undefined,
+      configRemoved: true,
+      name: "Manual Project",
+    })
+
+    const insert = vi.fn().mockResolvedValue("tombstone_id")
+    const ctx = createRemoveCtx({ repoProjects: [orphanManual], insert })
+
+    const result = await (removeAllOrphans as any).handler(ctx, REMOVE_ARGS)
+
+    expect(result.removed).toBe(1)
+    // No tombstone should be inserted for non-config projects
+    const tombstoneInserts = insert.mock.calls.filter((c: any) => c[0] === "deletedConfigProjects")
+    expect(tombstoneInserts).toHaveLength(0)
+  })
+
+  it("dedupes tombstones — skips insert when tombstone already exists", async () => {
+    const orphan = makeProject({
+      _id: "orphan_dup",
+      configProjectId: "old-blog",
+      frameworkSource: "config",
+      configRemoved: true,
+      name: "Old Blog",
+    })
+
+    const insert = vi.fn().mockResolvedValue("tombstone_id")
+    const existingTombstone = { _id: "existing_tombstone", configProjectId: "old-blog" }
+    const ctx = createRemoveCtx({ repoProjects: [orphan], insert, existingTombstone })
+
+    const result = await (removeAllOrphans as any).handler(ctx, REMOVE_ARGS)
+
+    expect(result.removed).toBe(1)
+    // Should NOT insert a tombstone since one already exists
+    const tombstoneInserts = insert.mock.calls.filter((c: any) => c[0] === "deletedConfigProjects")
+    expect(tombstoneInserts).toHaveLength(0)
   })
 })

--- a/lib/__tests__/sync-projects-from-config.test.ts
+++ b/lib/__tests__/sync-projects-from-config.test.ts
@@ -271,17 +271,35 @@ describe("syncProjectsFromConfig", () => {
   // ── Tombstone / deletion ─────────────────────────────────────────────────
 
   describe("tombstone (deletedConfigProjects)", () => {
-    it("skips a project whose configProjectId is tombstoned", async () => {
+    it("clears tombstone and creates project when configProjectId reappears in config", async () => {
       const tombstone = { _id: "tomb_1", repoOwner: "acme", repoName: "docs", configProjectId: "docs" }
-      const insert = vi.fn()
-      const patch = vi.fn()
-      const ctx = createCtx({ repoProjects: [], tombstone, insert, patch })
+      const insert = vi.fn().mockResolvedValue("recreated_proj_id")
+      const ctx = createCtx({ repoProjects: [], tombstone, insert })
+      const deleteDoc = ctx.db.delete
 
       const result = await (syncProjectsFromConfig as any).handler(ctx, BASE_ARGS)
 
+      // Tombstone must be deleted so the project can be re-created
+      expect(deleteDoc).toHaveBeenCalledWith("tomb_1")
+      // Project must be created fresh
+      expect(insert).toHaveBeenCalledWith("projects", expect.objectContaining({ configProjectId: "docs" }))
+      expect(result.created).toContain("recreated_proj_id")
+    })
+
+    it("does NOT clear tombstone for Studio auto-syncs (runOrphanDetection: false)", async () => {
+      // Studio auto-syncs pass runOrphanDetection: false to avoid false orphaning on
+      // non-default branches. They must also skip tombstone clearing to prevent
+      // non-owner page loads from resurrecting owner-deleted projects.
+      const tombstone = { _id: "tomb_1", repoOwner: "acme", repoName: "docs", configProjectId: "docs" }
+      const insert = vi.fn()
+      const ctx = createCtx({ repoProjects: [], tombstone, insert })
+
+      await (syncProjectsFromConfig as any).handler(ctx, { ...BASE_ARGS, runOrphanDetection: false })
+
+      // Tombstone must NOT be cleared
+      expect(ctx.db.delete).not.toHaveBeenCalled()
+      // Project must NOT be created
       expect(insert).not.toHaveBeenCalled()
-      expect(patch).not.toHaveBeenCalled()
-      expect(result.created).toHaveLength(0)
     })
   })
 

--- a/lib/__tests__/sync-projects-from-config.test.ts
+++ b/lib/__tests__/sync-projects-from-config.test.ts
@@ -271,34 +271,42 @@ describe("syncProjectsFromConfig", () => {
   // ── Tombstone / deletion ─────────────────────────────────────────────────
 
   describe("tombstone (deletedConfigProjects)", () => {
-    it("clears tombstone and creates project when configProjectId reappears in config", async () => {
-      const tombstone = { _id: "tomb_1", repoOwner: "acme", repoName: "docs", configProjectId: "docs" }
-      const insert = vi.fn().mockResolvedValue("recreated_proj_id")
-      const ctx = createCtx({ repoProjects: [], tombstone, insert })
-      const deleteDoc = ctx.db.delete
-
-      const result = await (syncProjectsFromConfig as any).handler(ctx, BASE_ARGS)
-
-      // Tombstone must be deleted so the project can be re-created
-      expect(deleteDoc).toHaveBeenCalledWith("tomb_1")
-      // Project must be created fresh
-      expect(insert).toHaveBeenCalledWith("projects", expect.objectContaining({ configProjectId: "docs" }))
-      expect(result.created).toContain("recreated_proj_id")
-    })
-
-    it("does NOT clear tombstone for Studio auto-syncs (runOrphanDetection: false)", async () => {
-      // Studio auto-syncs pass runOrphanDetection: false to avoid false orphaning on
-      // non-default branches. They must also skip tombstone clearing to prevent
-      // non-owner page loads from resurrecting owner-deleted projects.
+    it("skips tombstoned projects by default during sync", async () => {
       const tombstone = { _id: "tomb_1", repoOwner: "acme", repoName: "docs", configProjectId: "docs" }
       const insert = vi.fn()
       const ctx = createCtx({ repoProjects: [], tombstone, insert })
 
-      await (syncProjectsFromConfig as any).handler(ctx, { ...BASE_ARGS, runOrphanDetection: false })
+      const result = await (syncProjectsFromConfig as any).handler(ctx, BASE_ARGS)
 
-      // Tombstone must NOT be cleared
       expect(ctx.db.delete).not.toHaveBeenCalled()
-      // Project must NOT be created
+      expect(insert).not.toHaveBeenCalled()
+      expect(result.created).toHaveLength(0)
+    })
+
+    it("clears tombstone only when explicit clearTombstones is requested", async () => {
+      const tombstone = { _id: "tomb_1", repoOwner: "acme", repoName: "docs", configProjectId: "docs" }
+      const insert = vi.fn().mockResolvedValue("recreated_proj_id")
+      const ctx = createCtx({ repoProjects: [], tombstone, insert })
+
+      const result = await (syncProjectsFromConfig as any).handler(ctx, { ...BASE_ARGS, clearTombstones: true })
+
+      expect(ctx.db.delete).toHaveBeenCalledWith("tomb_1")
+      expect(insert).toHaveBeenCalledWith("projects", expect.objectContaining({ configProjectId: "docs" }))
+      expect(result.created).toContain("recreated_proj_id")
+    })
+
+    it("does NOT clear tombstone for Studio auto-syncs even if clearTombstones is set", async () => {
+      const tombstone = { _id: "tomb_1", repoOwner: "acme", repoName: "docs", configProjectId: "docs" }
+      const insert = vi.fn()
+      const ctx = createCtx({ repoProjects: [], tombstone, insert })
+
+      await (syncProjectsFromConfig as any).handler(ctx, {
+        ...BASE_ARGS,
+        runOrphanDetection: false,
+        clearTombstones: true,
+      })
+
+      expect(ctx.db.delete).not.toHaveBeenCalled()
       expect(insert).not.toHaveBeenCalled()
     })
   })
@@ -538,7 +546,7 @@ describe("getOrCreate", () => {
   })
 
   function createGetOrCreateCtx({
-    existingProject = null as ProjectRow | null,
+    matchingProjects = [] as ProjectRow[],
     patch = vi.fn(),
     insert = vi.fn().mockResolvedValue("new_project_id"),
   } = {}) {
@@ -551,7 +559,7 @@ describe("getOrCreate", () => {
         query: vi.fn((_table: string) => ({
           withIndex: (_index: string, _fn: unknown) => ({
             filter: (_filterFn: unknown) => ({
-              first: vi.fn().mockResolvedValue(existingProject),
+              collect: vi.fn().mockResolvedValue(matchingProjects),
             }),
           }),
         })),
@@ -577,7 +585,7 @@ describe("getOrCreate", () => {
       configRemovedAt: 1000000,
     })
     const patch = vi.fn()
-    const ctx = createGetOrCreateCtx({ existingProject: orphanedProject, patch })
+    const ctx = createGetOrCreateCtx({ matchingProjects: [orphanedProject], patch })
 
     const result = await (getOrCreate as any).handler(ctx, GET_OR_CREATE_ARGS)
 
@@ -593,7 +601,7 @@ describe("getOrCreate", () => {
     })
     const patch = vi.fn()
     const insert = vi.fn().mockResolvedValue("new_proj_id")
-    const ctx = createGetOrCreateCtx({ existingProject: deletingProject, patch, insert })
+    const ctx = createGetOrCreateCtx({ matchingProjects: [deletingProject], patch, insert })
 
     const result = await (getOrCreate as any).handler(ctx, GET_OR_CREATE_ARGS)
 
@@ -610,13 +618,37 @@ describe("getOrCreate", () => {
     )
   })
 
+  it("returns the recreated project when a deleting row still exists", async () => {
+    const deletingProject = makeProject({
+      _id: "proj_deleting",
+      name: "[DELETING] Old Blog",
+    })
+    const recreatedProject = makeProject({
+      _id: "proj_recreated",
+      name: "Docs",
+    })
+    const patch = vi.fn()
+    const insert = vi.fn()
+    const ctx = createGetOrCreateCtx({
+      matchingProjects: [deletingProject, recreatedProject],
+      patch,
+      insert,
+    })
+
+    const result = await (getOrCreate as any).handler(ctx, GET_OR_CREATE_ARGS)
+
+    expect(result).toBe("proj_recreated")
+    expect(insert).not.toHaveBeenCalled()
+    expect(patch).not.toHaveBeenCalled()
+  })
+
   it("does NOT clear configRemoved when project is not orphaned", async () => {
     const normalProject = makeProject({
       _id: "proj_normal",
       configRemoved: undefined,
     })
     const patch = vi.fn()
-    const ctx = createGetOrCreateCtx({ existingProject: normalProject, patch })
+    const ctx = createGetOrCreateCtx({ matchingProjects: [normalProject], patch })
 
     const result = await (getOrCreate as any).handler(ctx, GET_OR_CREATE_ARGS)
 

--- a/lib/__tests__/sync-projects-from-config.test.ts
+++ b/lib/__tests__/sync-projects-from-config.test.ts
@@ -283,19 +283,36 @@ describe("syncProjectsFromConfig", () => {
       expect(result.created).toHaveLength(0)
     })
 
-    it("clears tombstone only when explicit clearTombstones is requested", async () => {
+    it("clears tombstone only when the project ID is explicitly restored", async () => {
       const tombstone = { _id: "tomb_1", repoOwner: "acme", repoName: "docs", configProjectId: "docs" }
       const insert = vi.fn().mockResolvedValue("recreated_proj_id")
       const ctx = createCtx({ repoProjects: [], tombstone, insert })
 
-      const result = await (syncProjectsFromConfig as any).handler(ctx, { ...BASE_ARGS, clearTombstones: true })
+      const result = await (syncProjectsFromConfig as any).handler(ctx, {
+        ...BASE_ARGS,
+        restoredConfigProjectIds: ["docs"],
+      })
 
       expect(ctx.db.delete).toHaveBeenCalledWith("tomb_1")
       expect(insert).toHaveBeenCalledWith("projects", expect.objectContaining({ configProjectId: "docs" }))
       expect(result.created).toContain("recreated_proj_id")
     })
 
-    it("does NOT clear tombstone for Studio auto-syncs even if clearTombstones is set", async () => {
+    it("does not clear a tombstone when a different project was restored", async () => {
+      const tombstone = { _id: "tomb_1", repoOwner: "acme", repoName: "docs", configProjectId: "docs" }
+      const insert = vi.fn()
+      const ctx = createCtx({ repoProjects: [], tombstone, insert })
+
+      await (syncProjectsFromConfig as any).handler(ctx, {
+        ...BASE_ARGS,
+        restoredConfigProjectIds: ["blog"],
+      })
+
+      expect(ctx.db.delete).not.toHaveBeenCalled()
+      expect(insert).not.toHaveBeenCalled()
+    })
+
+    it("does NOT clear tombstone for Studio auto-syncs even if the project ID is restored", async () => {
       const tombstone = { _id: "tomb_1", repoOwner: "acme", repoName: "docs", configProjectId: "docs" }
       const insert = vi.fn()
       const ctx = createCtx({ repoProjects: [], tombstone, insert })
@@ -303,7 +320,7 @@ describe("syncProjectsFromConfig", () => {
       await (syncProjectsFromConfig as any).handler(ctx, {
         ...BASE_ARGS,
         runOrphanDetection: false,
-        clearTombstones: true,
+        restoredConfigProjectIds: ["docs"],
       })
 
       expect(ctx.db.delete).not.toHaveBeenCalled()

--- a/lib/sync-projects.ts
+++ b/lib/sync-projects.ts
@@ -19,8 +19,11 @@ export async function syncProjectsServerSide(
   repo: string,
   branch: string,
   actingUserId: string,
-  { runOrphanDetection = true }: { runOrphanDetection?: boolean } = {},
-): Promise<{ synced: string[]; created: string[]; unchanged: string[] } | null> {
+  {
+    runOrphanDetection = true,
+    clearTombstones = false,
+  }: { runOrphanDetection?: boolean; clearTombstones?: boolean } = {},
+): Promise<{ synced: string[]; created: string[]; unchanged: string[]; orphaned?: string[] } | null> {
   if (!convexUrl) return null
 
   const { config } = await fetchRepoConfig(token, owner, repo, branch)
@@ -51,6 +54,7 @@ export async function syncProjectsServerSide(
     configPath: "repopress.config.json",
     pluginRegistry: config.plugins,
     runOrphanDetection,
+    clearTombstones,
     projects: projectsToSync,
   })
 

--- a/lib/sync-projects.ts
+++ b/lib/sync-projects.ts
@@ -54,6 +54,15 @@ export async function syncProjectsServerSide(
     projects: projectsToSync,
   })
 
+  if (result) {
+    const parts = [`Sync complete for ${owner}/${repo}:`]
+    if (result.created.length) parts.push(`${result.created.length} created`)
+    if (result.synced.length) parts.push(`${result.synced.length} updated`)
+    if (result.unchanged.length) parts.push(`${result.unchanged.length} unchanged`)
+    if ((result as any).orphaned?.length) parts.push(`${(result as any).orphaned.length} orphaned`)
+    console.log(parts.join(" "))
+  }
+
   return result
 }
 

--- a/lib/sync-projects.ts
+++ b/lib/sync-projects.ts
@@ -21,8 +21,8 @@ export async function syncProjectsServerSide(
   actingUserId: string,
   {
     runOrphanDetection = true,
-    clearTombstones = false,
-  }: { runOrphanDetection?: boolean; clearTombstones?: boolean } = {},
+    restoredConfigProjectIds,
+  }: { runOrphanDetection?: boolean; restoredConfigProjectIds?: string[] } = {},
 ): Promise<{ synced: string[]; created: string[]; unchanged: string[]; orphaned?: string[] } | null> {
   if (!convexUrl) return null
 
@@ -54,7 +54,7 @@ export async function syncProjectsServerSide(
     configPath: "repopress.config.json",
     pluginRegistry: config.plugins,
     runOrphanDetection,
-    clearTombstones,
+    restoredConfigProjectIds,
     projects: projectsToSync,
   })
 


### PR DESCRIPTION
## Root Cause

Stale Convex project records from past dev sessions remained in the production database after their `configProjectId` was removed from `repopress.config.json`. The sync logic correctly flagged them as orphans but lacked a bulk-cleanup mechanism, leaving users with repeated warning cards and no easy way to clean up.

---

## Changes

### Fix 1 — Batch orphan cleanup (core fix)
- **`convex/projects.ts`**: Added `removeAllOrphans` mutation (batch cap 25, tombstone deduplication, returns `{removed, remaining}`)
- **`app/dashboard/.../config-actions.ts`**: Added `cleanUpAllOrphansAction` server action (owner-only via `serverQueryToken`)
- **`components/repo-project-hub.tsx`**: Added owner-only "Remove All" button with toast showing remaining count
- **`convex/projects.ts` (`getOrCreate`)**: Skips projects with `[DELETING]` prefix to prevent zombie resurrection mid-batch

### Fix 2 — Finding 9 🔴 (security): Gate tombstone clearing on canonical syncs
Studio auto-syncs (`runOrphanDetection: false`) run on every page load and may be triggered by non-owner users. They previously cleared tombstones unconditionally, which would silently resurrect a project the owner intentionally deleted.

**Fix:** `syncProjectsFromConfig` now skips tombstone clearing when `runOrphanDetection === false`. Only `retrySyncAction` and explicit config edits (`runOrphanDetection: true`, the default) may clear tombstones — these are deliberate user-initiated actions.

### Fix 3 — Finding 8 🟡 (UX): Confirmation dialog before permanent delete
Replaced the inline one-click delete handler on `orphan-warning-card.tsx` with `DeleteProjectDialog` (AlertDialog). Permanent deletion now shows the project name and requires clicking "Delete Permanently" in a modal.

### Fix 4 — Finding 3 🟢 (tests): Server action test coverage
Added 5 tests for `cleanUpAllOrphansAction`: happy path, unauthenticated, non-owner, partial batch (`remaining > 0`), and Convex mutation error.

Added regression test: *"does NOT clear tombstone for Studio auto-syncs (runOrphanDetection: false)"* to prevent future removal of the guard.

---

## Before / After

| | Before | After |
|---|---|---|
| Orphan cleanup | One-by-one only | Bulk "Remove All" + individual confirm dialog |
| Tombstone resurrection | Any page load could clear tombstones | Only canonical/user-initiated syncs clear tombstones |
| Permanent delete UX | One-click, no confirmation | AlertDialog with project name confirmation |
| Server action tests | None for `cleanUpAllOrphansAction` | 5 tests added |

---

## Verification

- ✅ `npm run test`: **463 tests, 0 failed**
- ✅ `npm run lint`: clean (14 pre-existing warnings, 0 errors)