### PR TITLE
feat: folder picker for content root selection

### DIFF
--- a/app/api/github/tree/route.ts
+++ b/app/api/github/tree/route.ts
@@ -1,0 +1,23 @@
+import type { NextRequest } from "next/server"
+import { getGitHubToken } from "@/lib/auth-server"
+import { getContentTree } from "@/lib/github"
+
+export async function GET(request: NextRequest) {
+  const token = await getGitHubToken()
+  if (!token) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  const { searchParams } = request.nextUrl
+  const owner = searchParams.get("owner")
+  const repo = searchParams.get("repo")
+  const branch = searchParams.get("branch") ?? "main"
+  const contentRoot = searchParams.get("contentRoot") ?? ""
+
+  if (!owner || !repo) {
+    return Response.json({ error: "Missing required params: owner and repo" }, { status: 400 })
+  }
+
+  const tree = await getContentTree(token, owner, repo, branch, contentRoot)
+  return Response.json(tree)
+}

--- a/app/dashboard/[owner]/[repo]/actions.ts
+++ b/app/dashboard/[owner]/[repo]/actions.ts
@@ -3,6 +3,7 @@
 import { revalidatePath } from "next/cache"
 import { api } from "@/convex/_generated/api"
 import { fetchAuthMutation, fetchAuthQuery, getGitHubToken, getPatAuthUserId } from "@/lib/auth-server"
+import { getRepoContents } from "@/lib/github"
 import { fetchRepoConfig } from "@/lib/repopress/config"
 import { syncProjectsServerSide } from "@/lib/sync-projects"
 
@@ -28,7 +29,31 @@ export async function syncProjectsFromConfigAction(owner: string, repo: string, 
     }
 
     revalidatePath(`/dashboard/${owner}/${repo}`)
-    return { success: true, count: result.synced.length + result.created.length + result.unchanged.length }
+    return {
+      success: true,
+      count: result.synced.length + result.created.length + result.unchanged.length,
+    }
+  } catch (error: any) {
+    return { success: false, error: error.message }
+  }
+}
+
+export async function fetchRepoDirsAction(
+  owner: string,
+  repo: string,
+  path: string,
+  branch: string,
+): Promise<{ success: true; dirs: { name: string; path: string }[] } | { success: false; error: string }> {
+  const token = await getGitHubToken()
+  if (!token) return { success: false, error: "Not authenticated with GitHub" }
+
+  try {
+    const contents = await getRepoContents(token, owner, repo, path, branch)
+    const dirs = contents
+      .filter((entry) => entry.type === "dir")
+      .map((entry) => ({ name: entry.name, path: entry.path }))
+      .sort((a, b) => a.name.localeCompare(b.name))
+    return { success: true, dirs }
   } catch (error: any) {
     return { success: false, error: error.message }
   }

--- a/app/dashboard/[owner]/[repo]/actions.ts
+++ b/app/dashboard/[owner]/[repo]/actions.ts
@@ -2,9 +2,8 @@
 
 import { revalidatePath } from "next/cache"
 import { api } from "@/convex/_generated/api"
-import { fetchAuthMutation, fetchAuthQuery, getGitHubToken, getPatAuthUserId } from "@/lib/auth-server"
+import { fetchAuthQuery, getGitHubToken, getPatAuthUserId } from "@/lib/auth-server"
 import { getRepoContents } from "@/lib/github"
-import { fetchRepoConfig } from "@/lib/repopress/config"
 import { syncProjectsServerSide } from "@/lib/sync-projects"
 
 export async function syncProjectsFromConfigAction(owner: string, repo: string, branch: string) {

--- a/app/dashboard/[owner]/[repo]/config-actions.ts
+++ b/app/dashboard/[owner]/[repo]/config-actions.ts
@@ -81,9 +81,16 @@ async function resolveProjectOwnerActionContext(projectId: string): Promise<Proj
     throw new Error("Project not found")
   }
 
-  const { role } = await resolveRepoRole(token, project.repoOwner, project.repoName, actingUserId)
-  if (role !== "owner") {
-    throw new Error("Unauthorized: owner access required")
+  // Primary check: Convex project ownership. This is the authoritative record and
+  // works regardless of OAuth scope limitations that can prevent GitHub's permissions
+  // field from being returned by repos.get().
+  const isConvexOwner = (project as any).userId === actingUserId
+  if (!isConvexOwner) {
+    // Fallback: GitHub admin access (e.g. org admins who didn't create the project).
+    const { role } = await resolveRepoRole(token, project.repoOwner, project.repoName, actingUserId)
+    if (role !== "owner") {
+      throw new Error("Unauthorized: owner access required")
+    }
   }
 
   const projectAccessToken = await mintProjectAccessToken({

--- a/app/dashboard/[owner]/[repo]/config-actions.ts
+++ b/app/dashboard/[owner]/[repo]/config-actions.ts
@@ -51,7 +51,10 @@ async function fetchConfigOrThrow(token: string, owner: string, repo: string, br
 }
 
 type ConfigActionResult =
-  | { success: true; syncResult?: { synced: string[]; created: string[]; unchanged: string[] } }
+  | {
+      success: true
+      syncResult?: { synced: string[]; created: string[]; unchanged: string[] }
+    }
   | { success: false; error: string }
 
 type ProjectResolutionResult = {
@@ -170,12 +173,42 @@ export async function updateProjectInConfigAction(
   repo: string,
   branch: string,
   configProjectId: string,
-  updates: Partial<Pick<ProjectConfig, "name" | "framework" | "contentType" | "branch" | "preview" | "components">>,
+  updates: Partial<
+    Pick<ProjectConfig, "name" | "framework" | "contentType" | "branch" | "preview" | "components" | "contentRoot">
+  >,
 ): Promise<ConfigActionResult> {
   try {
     const { token, actingUserId } = await resolveAuthContext()
     await requireWriteAccess(token, owner, repo, actingUserId)
     const { config, sha } = await fetchConfigOrThrow(token, owner, repo, branch)
+
+    // Validate contentRoot directory exists if it's being updated
+    if (updates.contentRoot !== undefined && updates.contentRoot !== "") {
+      const { createGitHubClient } = await import("@/lib/github")
+      const octokit = createGitHubClient(token)
+      try {
+        const { data } = await octokit.repos.getContent({
+          owner,
+          repo,
+          path: updates.contentRoot,
+          ref: branch,
+        })
+        if (!Array.isArray(data)) {
+          return {
+            success: false,
+            error: `"${updates.contentRoot}" is a file, not a folder.`,
+          }
+        }
+      } catch (err: any) {
+        if (err.status === 404) {
+          return {
+            success: false,
+            error: `Folder "${updates.contentRoot}" does not exist in ${owner}/${repo} on branch ${branch}.`,
+          }
+        }
+        // Non-404 errors: let through to avoid blocking on transient failures
+      }
+    }
 
     const updatedConfig = updateProject(config, configProjectId, updates)
     await commitConfig(

--- a/app/dashboard/[owner]/[repo]/page.tsx
+++ b/app/dashboard/[owner]/[repo]/page.tsx
@@ -4,7 +4,7 @@ import { RepoProjectHub } from "@/components/repo-project-hub"
 import { api } from "@/convex/_generated/api"
 import { fetchAuthQuery, getGitHubToken, getPatAuthUserId } from "@/lib/auth-server"
 import { resolveRepoRole } from "@/lib/github-permissions"
-import { mintServerQueryToken } from "@/lib/project-access-token"
+import { mintProjectAccessToken, mintServerQueryToken } from "@/lib/project-access-token"
 import { fetchRepoConfig } from "@/lib/repopress/config"
 import { syncProjectsServerSide } from "@/lib/sync-projects"
 
@@ -66,6 +66,30 @@ export default async function RepoPage({ params }: RepoPageProps) {
     repoName: repo,
     serverQueryToken,
   })
+  const projectAccessTokens: Record<string, string> = {}
+
+  if (actingUserId) {
+    const tokens = await Promise.all(
+      projects.map(
+        async (project) =>
+          [
+            project._id,
+            await mintProjectAccessToken({
+              projectId: project._id,
+              userId: actingUserId,
+              repoOwner: project.repoOwner,
+              repoName: project.repoName,
+              branch: project.branch,
+              role: repoRole,
+            }),
+          ] as const,
+      ),
+    )
+
+    for (const [projectId, token] of tokens) {
+      projectAccessTokens[projectId] = token
+    }
+  }
 
   const hasConfig = !!config
   const configSynced = hasConfig && !syncError
@@ -100,6 +124,7 @@ export default async function RepoPage({ params }: RepoPageProps) {
         configJson={config ? JSON.stringify(config, null, 2) : null}
         configSha={configSha ?? null}
         actingUserId={actingUserId}
+        projectAccessTokens={projectAccessTokens}
       />
     </div>
   )

--- a/app/dashboard/[owner]/[repo]/studio/[[...path]]/page.tsx
+++ b/app/dashboard/[owner]/[repo]/studio/[[...path]]/page.tsx
@@ -1,15 +1,12 @@
 import { ConvexHttpClient } from "convex/browser"
-import { AlertCircle } from "lucide-react"
 import { redirect } from "next/navigation"
 import { StudioLayout } from "@/components/studio/studio-layout"
 import { StudioPageThemeToggle } from "@/components/studio/studio-page-theme-toggle"
-import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { api } from "@/convex/_generated/api"
 import type { Doc, Id } from "@/convex/_generated/dataModel"
 import { fetchAuthQuery, getGitHubToken, getPatAuthUserId } from "@/lib/auth-server"
-import type { FileTreeNode } from "@/lib/github"
-import { createGitHubClient, getContentTree, getFile } from "@/lib/github"
-import { getRepoRole, probeRepoReadAccess } from "@/lib/github-permissions"
+import { createGitHubClient, getFile } from "@/lib/github"
+import { resolveRepoRole } from "@/lib/github-permissions"
 import { mintProjectAccessToken, mintServerQueryToken } from "@/lib/project-access-token"
 import { projectMatchesRoute, selectStudioFallbackProject } from "@/lib/studio/project-route"
 
@@ -28,73 +25,61 @@ interface StudioPageProps {
   }>
 }
 
-export default async function StudioPage({ params, searchParams }: StudioPageProps) {
-  const token = await getGitHubToken()
+export default async function StudioPage({
+  params: paramsPromise,
+  searchParams: searchParamsPromise,
+}: StudioPageProps) {
+  // Batch 1: all independent setup calls run in parallel
+  const [token, authUser, serverQueryToken, resolvedParams, resolvedSearchParams] = await Promise.all([
+    getGitHubToken(),
+    fetchAuthQuery ? fetchAuthQuery(api.auth.getCurrentUser).catch(() => null) : Promise.resolve(null),
+    mintServerQueryToken(),
+    paramsPromise,
+    searchParamsPromise,
+  ])
 
-  if (!token) {
-    redirect("/login")
-  }
+  if (!token) redirect("/login")
 
-  const { owner, repo, path } = await params
-  const { branch, projectId: projectIdParam, file } = await searchParams
-  const currentBranch = branch || "main"
+  const { owner, repo, path } = resolvedParams
+  const { branch, projectId: projectIdParam, file } = resolvedSearchParams
   const currentPath = file || (path ? path.join("/") : "")
-  const authUser = fetchAuthQuery ? await fetchAuthQuery(api.auth.getCurrentUser).catch(() => null) : null
+
   const patUserId = !authUser ? await getPatAuthUserId(token) : null
   const actingUserId = (authUser?._id as string | undefined) ?? patUserId
 
   const convex = new ConvexHttpClient(process.env.NEXT_PUBLIC_CONVEX_URL!)
-  const serverQueryToken = await mintServerQueryToken()
 
-  // Look up the project first (needed for ownership fallback)
+  // Batch 2: project lookups + role resolution run in parallel.
+  // listProjectsForRepo always runs (eliminates the sequential fallback on the common path).
+  const [requestedProject, repoProjects, { role: resolvedRole, defaultBranch }] = await Promise.all([
+    projectIdParam
+      ? convex.query(api.projects.get, { id: projectIdParam as Id<"projects">, serverQueryToken })
+      : Promise.resolve(null),
+    convex.query(api.projects.listProjectsForRepo, { repoOwner: owner, repoName: repo, serverQueryToken }),
+    resolveRepoRole(token, owner, repo, actingUserId),
+  ])
+
+  // Effective branch: URL param wins, then API default, then "main"
+  const currentBranch = branch || defaultBranch || "main"
+
+  // Resolve project: try the specific project first, then fall back to repo-level lookup
   let project: Doc<"projects"> | null = null
-  if (projectIdParam) {
-    const requestedProject = await convex.query(api.projects.get, {
-      id: projectIdParam as Id<"projects">,
-      serverQueryToken,
-    })
-    if (
-      projectMatchesRoute(requestedProject, owner, repo, currentBranch) &&
-      requestedProject &&
-      actingUserId &&
-      requestedProject.userId === actingUserId
-    ) {
-      project = requestedProject
-    }
+  if (
+    requestedProject &&
+    projectMatchesRoute(requestedProject, owner, repo, currentBranch) &&
+    actingUserId &&
+    requestedProject.userId === actingUserId
+  ) {
+    project = requestedProject
   }
   if (!project) {
-    const repoProjects = await convex.query(api.projects.listProjectsForRepo, {
-      repoOwner: owner,
-      repoName: repo,
-      serverQueryToken,
-    })
     project = selectStudioFallbackProject(repoProjects, currentBranch)
   }
 
-  // Resolve role: GitHub API → ownership → cache → content probe
-  const { role: githubRole } = await getRepoRole(token, owner, repo)
+  // Ownership check happens AFTER final project is selected so the upgrade applies
+  // regardless of whether the project came from the specific lookup or the fallback.
   const isProjectOwner = !!(project && actingUserId && project.userId === actingUserId)
-  let repoRole: Role | null = githubRole ?? (isProjectOwner ? "owner" : null)
-
-  // Fallback chain for org-repo collaborators where getRepoRole returns null
-  if (!repoRole && actingUserId) {
-    // 1. Check access cache (seeded by prior visits)
-    try {
-      const cached = await convex.query(api.repoAccessCache.getForUserPublic, {
-        repoOwner: owner,
-        repoName: repo,
-        userId: actingUserId,
-        serverQueryToken,
-      })
-      if (cached) repoRole = cached.role as Role
-    } catch {
-      // Cache lookup failed
-    }
-    // 2. Probe: can the token actually read repo content?
-    if (!repoRole) {
-      repoRole = await probeRepoReadAccess(token, owner, repo)
-    }
-  }
+  const repoRole: Role | null = isProjectOwner ? "owner" : resolvedRole
 
   if (!repoRole) {
     redirect("/dashboard")
@@ -113,7 +98,7 @@ export default async function StudioPage({ params, searchParams }: StudioPagePro
         })
       : undefined
 
-  // Cache the permission in Convex (best-effort, requires projectAccessToken)
+  // Cache the permission in Convex (best-effort, non-critical)
   if (actingUserId && projectAccessToken) {
     try {
       const octokit = createGitHubClient(token)
@@ -131,24 +116,17 @@ export default async function StudioPage({ params, searchParams }: StudioPagePro
     }
   }
 
-  // Use project's contentRoot to scope file listing (falls back to repo root)
   const contentRoot = project?.contentRoot || ""
 
-  let tree: FileTreeNode[] = []
+  // Fetch initial file content server-side (fast for small files).
+  // The file tree is deferred to client-side to avoid blocking on large repos.
   let fileData = null
-  let error = null
-
   try {
-    // Always fetch the full content tree (filtered to .md/.mdx files)
-    tree = await getContentTree(token, owner, repo, currentBranch, contentRoot)
-
-    // When a specific path is requested, fetch the file content
     if (currentPath) {
       fileData = await getFile(token, owner, repo, currentPath, currentBranch)
     }
-  } catch (e) {
-    console.error("Error fetching studio data:", e)
-    error = "Failed to fetch repository data. Please try again later."
+  } catch {
+    // Non-critical: editor opens with empty content; user can reload from the file tree
   }
 
   return (
@@ -166,30 +144,20 @@ export default async function StudioPage({ params, searchParams }: StudioPagePro
         </div>
       </div>
 
-      {error ? (
-        <div className="w-full px-2 sm:px-3 py-8">
-          <Alert variant="destructive">
-            <AlertCircle className="h-4 w-4" />
-            <AlertTitle>Error</AlertTitle>
-            <AlertDescription>{error}</AlertDescription>
-          </Alert>
-        </div>
-      ) : (
-        <div className="flex-1 min-h-0">
-          <StudioLayout
-            tree={tree}
-            initialFile={fileData}
-            owner={owner}
-            repo={repo}
-            branch={currentBranch}
-            currentPath={currentPath}
-            projectId={project?._id}
-            projectAccessToken={projectAccessToken}
-            contentRoot={contentRoot}
-            role={repoRole}
-          />
-        </div>
-      )}
+      <div className="flex-1 min-h-0">
+        <StudioLayout
+          tree={[]}
+          initialFile={fileData}
+          owner={owner}
+          repo={repo}
+          branch={currentBranch}
+          currentPath={currentPath}
+          projectId={project?._id}
+          projectAccessToken={projectAccessToken}
+          contentRoot={contentRoot}
+          role={repoRole}
+        />
+      </div>
     </div>
   )
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -31,6 +31,7 @@
   --chart-4: oklch(0.828 0.189 84.429);
   --chart-5: oklch(0.769 0.188 70.08);
   --radius: 0.625rem;
+  --card-radius: 1rem;
   --sidebar: oklch(0.985 0 0);
   --sidebar-foreground: oklch(0.145 0 0);
   --sidebar-primary: oklch(0.205 0 0);
@@ -120,6 +121,7 @@
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);
   --radius-xl: calc(var(--radius) + 4px);
+  --radius-ele: var(--radius);
   --color-sidebar: var(--sidebar);
   --color-sidebar-foreground: var(--sidebar-foreground);
   --color-sidebar-primary: var(--sidebar-primary);

--- a/components/__tests__/edit-project-dialog.test.tsx
+++ b/components/__tests__/edit-project-dialog.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+import "@testing-library/jest-dom/vitest"
+import { render } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const { useQueryMock } = vi.hoisted(() => ({
+  useQueryMock: vi.fn(),
+}))
+
+vi.mock("convex/react", () => ({
+  useQuery: useQueryMock,
+}))
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}))
+
+vi.mock("@/app/dashboard/[owner]/[repo]/config-actions", () => ({
+  updateProjectInConfigAction: vi.fn(),
+}))
+
+import { EditProjectDialog } from "../edit-project-dialog"
+
+describe("EditProjectDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useQueryMock.mockReturnValue(false)
+  })
+
+  it("passes projectAccessToken to the hasContent query", () => {
+    render(
+      <EditProjectDialog
+        owner="acme"
+        repo="docs"
+        defaultBranch="main"
+        project={{
+          _id: "project_123",
+          name: "Docs",
+          contentRoot: "",
+          contentType: "docs",
+          branch: "main",
+          configProjectId: "docs",
+          projectAccessToken: "pat-token",
+        }}
+        open
+        onOpenChange={vi.fn()}
+      />,
+    )
+
+    expect(useQueryMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        projectId: "project_123",
+        projectAccessToken: "pat-token",
+      }),
+    )
+  })
+})

--- a/components/__tests__/folder-picker-dialog.test.tsx
+++ b/components/__tests__/folder-picker-dialog.test.tsx
@@ -1,0 +1,169 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { render, screen, fireEvent, waitFor } from "@testing-library/react"
+import { FolderPickerDialog } from "../folder-picker-dialog"
+
+// Mock the server action
+const { fetchRepoDirsActionMock } = vi.hoisted(() => ({
+  fetchRepoDirsActionMock: vi.fn(),
+}))
+
+vi.mock("@/app/dashboard/[owner]/[repo]/actions", () => ({
+  fetchRepoDirsAction: fetchRepoDirsActionMock,
+}))
+
+const DEFAULT_DIRS = [
+  { name: "content", path: "content" },
+  { name: "src", path: "src" },
+  { name: "lib", path: "lib" },
+]
+
+function setupMock(
+  result?: { success: true; dirs: { name: string; path: string }[] } | { success: false; error: string },
+) {
+  if (!result) {
+    result = { success: true, dirs: DEFAULT_DIRS }
+  }
+  fetchRepoDirsActionMock.mockResolvedValue(result)
+}
+
+describe("FolderPickerDialog", () => {
+  const defaultProps = {
+    open: true,
+    onOpenChange: vi.fn(),
+    onSelect: vi.fn(),
+    owner: "acme",
+    repo: "docs",
+    branch: "main",
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setupMock()
+  })
+
+  it("renders repo root option", () => {
+    render(<FolderPickerDialog {...defaultProps} />)
+
+    // Get the first occurrence of "(repo root)" - it's in the folder selection list
+    expect(screen.getAllByText("(repo root)")[0]).toBeInTheDocument()
+  })
+
+  it("loads and displays root directories", async () => {
+    render(<FolderPickerDialog {...defaultProps} />)
+
+    await waitFor(() => {
+      expect(screen.getAllByText("content")[0]).toBeInTheDocument()
+      expect(screen.getAllByText("src")[0]).toBeInTheDocument()
+      expect(screen.getAllByText("lib")[0]).toBeInTheDocument()
+    })
+
+    expect(fetchRepoDirsActionMock).toHaveBeenCalledWith("acme", "docs", "", "main")
+  })
+
+  it("selects a folder and calls onSelect on confirm", async () => {
+    render(<FolderPickerDialog {...defaultProps} />)
+
+    // Wait for initial load
+    await waitFor(() => {
+      expect(screen.getAllByText("content")[0]).toBeInTheDocument()
+    })
+
+    // Find the content folder row and click the folder button (not the chevron)
+    // The folder name is in a button with the folder icon - use getByText to get the button directly
+    const contentFolderButton = screen.getByRole("button", {
+      name: /content/i,
+    })
+    fireEvent.click(contentFolderButton)
+
+    // Click Confirm
+    const confirmButton = screen.getByRole("button", { name: /confirm/i })
+    fireEvent.click(confirmButton)
+
+    expect(defaultProps.onSelect).toHaveBeenCalledWith("content")
+    expect(defaultProps.onOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  it("selects repo root by default when clicking Confirm without selecting a folder", async () => {
+    render(<FolderPickerDialog {...defaultProps} />)
+
+    // Wait for initial load
+    await waitFor(() => {
+      expect(screen.getAllByText("content")[0]).toBeInTheDocument()
+    })
+
+    // Click Confirm without selecting any folder
+    const confirmButton = screen.getByRole("button", { name: /confirm/i })
+    fireEvent.click(confirmButton)
+
+    expect(defaultProps.onSelect).toHaveBeenCalledWith("")
+  })
+
+  it("shows error state when fetch fails", async () => {
+    fetchRepoDirsActionMock.mockResolvedValue({
+      success: false,
+      error: "Failed to fetch directories",
+    } as const)
+
+    render(<FolderPickerDialog {...defaultProps} />)
+
+    await waitFor(() => {
+      expect(screen.getByText("Failed to fetch directories")).toBeInTheDocument()
+    })
+
+    expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument()
+  })
+
+  it("expands folder to load children", async () => {
+    // First call returns dirs with children, second call returns subdirs
+    const subDirs = [
+      { name: "nested", path: "content/nested" },
+      { name: "other", path: "content/other" },
+    ]
+
+    let callCount = 0
+    fetchRepoDirsActionMock.mockImplementation(() => {
+      callCount++
+      if (callCount === 1) {
+        return Promise.resolve({ success: true, dirs: DEFAULT_DIRS })
+      }
+      return Promise.resolve({ success: true, dirs: subDirs })
+    })
+
+    render(<FolderPickerDialog {...defaultProps} />)
+
+    // Wait for initial load
+    await waitFor(() => {
+      expect(screen.getAllByText("content")[0]).toBeInTheDocument()
+    })
+
+    // Find the content row and click the expand button (chevron)
+    // The content folder has a chevron button next to it
+    const contentButtons = screen.getAllByText("content")
+    const contentButton = contentButtons[0]
+    const contentRow = contentButton.closest("div")
+    // The expand button is the first button in the row (chevron)
+    const chevronButton = contentRow?.querySelector("button")
+
+    if (chevronButton) {
+      fireEvent.click(chevronButton)
+    }
+
+    // Wait for children to load
+    await waitFor(() => {
+      expect(screen.getByText("nested")).toBeInTheDocument()
+    })
+
+    expect(fetchRepoDirsActionMock).toHaveBeenCalledWith("acme", "docs", "content", "main")
+  })
+
+  it("does not re-fetch when dialog is closed", () => {
+    const { rerender } = render(<FolderPickerDialog {...defaultProps} open={false} />)
+
+    // No calls should have been made since open=false
+    expect(fetchRepoDirsActionMock).not.toHaveBeenCalled()
+
+    // Even re-rendering with open=false should not trigger fetch
+    rerender(<FolderPickerDialog {...defaultProps} open={false} />)
+    expect(fetchRepoDirsActionMock).not.toHaveBeenCalled()
+  })
+})

--- a/components/__tests__/folder-picker-dialog.test.tsx
+++ b/components/__tests__/folder-picker-dialog.test.tsx
@@ -1,5 +1,7 @@
+// @vitest-environment jsdom
+import "@testing-library/jest-dom/vitest"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
-import { render, screen, fireEvent, waitFor } from "@testing-library/react"
 import { FolderPickerDialog } from "../folder-picker-dialog"
 
 // Mock the server action

--- a/components/add-project-dialog.tsx
+++ b/components/add-project-dialog.tsx
@@ -4,12 +4,12 @@ import { Folder, FolderOpen, Loader2, Plus } from "lucide-react"
 import { useState, useTransition } from "react"
 import { toast } from "sonner"
 import { addProjectToConfigAction } from "@/app/dashboard/[owner]/[repo]/config-actions"
+import { FolderPickerDialog } from "./folder-picker-dialog"
 import { Button } from "./ui/button"
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "./ui/dialog"
 import { Input } from "./ui/input"
 import { Label } from "./ui/label"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "./ui/select"
-import { FolderPickerDialog } from "./folder-picker-dialog"
 
 const FRAMEWORK_OPTIONS = [
   { value: "auto", label: "Auto-detect" },

--- a/components/add-project-dialog.tsx
+++ b/components/add-project-dialog.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { Loader2, Plus } from "lucide-react"
+import { Folder, FolderOpen, Loader2, Plus } from "lucide-react"
 import { useState, useTransition } from "react"
 import { toast } from "sonner"
 import { addProjectToConfigAction } from "@/app/dashboard/[owner]/[repo]/config-actions"
@@ -9,6 +9,7 @@ import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, D
 import { Input } from "./ui/input"
 import { Label } from "./ui/label"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "./ui/select"
+import { FolderPickerDialog } from "./folder-picker-dialog"
 
 const FRAMEWORK_OPTIONS = [
   { value: "auto", label: "Auto-detect" },
@@ -55,6 +56,7 @@ export function AddProjectDialog({ owner, repo, defaultBranch, open, onOpenChang
   const [contentType, setContentType] = useState("custom")
   const [branch, setBranch] = useState("")
   const [error, setError] = useState<string | null>(null)
+  const [folderPickerOpen, setFolderPickerOpen] = useState(false)
 
   const projectId = slugify(name)
 
@@ -65,6 +67,7 @@ export function AddProjectDialog({ owner, repo, defaultBranch, open, onOpenChang
     setContentType("custom")
     setBranch("")
     setError(null)
+    setFolderPickerOpen(false)
   }
 
   const handleSubmit = () => {
@@ -135,17 +138,41 @@ export function AddProjectDialog({ owner, repo, defaultBranch, open, onOpenChang
           </div>
 
           <div className="grid gap-2">
-            <Label htmlFor="content-root">Content Root</Label>
-            <Input
-              id="content-root"
-              placeholder="e.g. content/blog (empty = repo root)"
-              value={contentRoot}
-              onChange={(e) => setContentRoot(e.target.value)}
-              disabled={isPending}
-            />
+            <Label>Content Root</Label>
+            <div className="flex gap-2">
+              <div className="relative flex-1">
+                <Folder className="absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
+                <Input
+                  readOnly
+                  value={contentRoot || "(repo root)"}
+                  onClick={() => !isPending && setFolderPickerOpen(true)}
+                  className="pl-9 cursor-pointer"
+                  disabled={isPending}
+                />
+              </div>
+              <Button
+                type="button"
+                variant="outline"
+                size="icon"
+                onClick={() => setFolderPickerOpen(true)}
+                disabled={isPending}
+                title="Browse directories"
+              >
+                <FolderOpen className="h-4 w-4" />
+              </Button>
+            </div>
             <p className="text-xs text-muted-foreground">
-              Relative path to a folder that already exists in your repository. Leave empty to use the repo root.
+              Browse and select a folder from your repository, or use the repo root.
             </p>
+            <FolderPickerDialog
+              open={folderPickerOpen}
+              onOpenChange={setFolderPickerOpen}
+              onSelect={(path) => setContentRoot(path)}
+              owner={owner}
+              repo={repo}
+              branch={branch.trim() || defaultBranch}
+              initialPath={contentRoot}
+            />
           </div>
 
           <div className="grid grid-cols-2 gap-4">

--- a/components/delete-project-dialog.tsx
+++ b/components/delete-project-dialog.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { Loader2, Trash2 } from "lucide-react"
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import { toast } from "sonner"
 import { deleteProjectPermanentlyAction } from "@/app/dashboard/[owner]/[repo]/config-actions"
 import {
@@ -14,6 +14,8 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog"
 import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
 
 interface DeleteProjectDialogProps {
   project: { _id: string; name: string } | null
@@ -24,6 +26,11 @@ interface DeleteProjectDialogProps {
 
 export function DeleteProjectDialog({ project, open, onOpenChange, onSuccess }: DeleteProjectDialogProps) {
   const [isDeleting, setIsDeleting] = useState(false)
+  const [confirmName, setConfirmName] = useState("")
+
+  useEffect(() => {
+    if (!open) setConfirmName("")
+  }, [open])
 
   const handleDelete = async () => {
     if (!project) return
@@ -49,16 +56,46 @@ export function DeleteProjectDialog({ project, open, onOpenChange, onSuccess }: 
         <AlertDialogHeader>
           <AlertDialogTitle>Delete &ldquo;{project?.name}&rdquo;?</AlertDialogTitle>
           <AlertDialogDescription>
-            This will permanently delete <strong>{project?.name}</strong> and all its drafts, history, and metadata in
-            RepoPress. This action cannot be undone.
+            This will permanently delete{" "}
+            <button
+              type="button"
+              className="inline font-bold cursor-pointer hover:underline bg-transparent border-0 p-0 text-inherit"
+              title="Click to fill"
+              onClick={() => setConfirmName(project?.name ?? "")}
+            >
+              {project?.name}
+            </button>{" "}
+            and all its drafts, history, and metadata in RepoPress. This action cannot be undone.
           </AlertDialogDescription>
         </AlertDialogHeader>
+        <div className="my-4 space-y-2">
+          <Label htmlFor="confirmDeleteName" className="text-sm">
+            Type{" "}
+            <button
+              type="button"
+              className="inline font-mono font-bold text-foreground cursor-pointer hover:underline bg-transparent border-0 p-0 text-sm"
+              title="Click to fill"
+              onClick={() => setConfirmName(project?.name ?? "")}
+            >
+              {project?.name}
+            </button>{" "}
+            to confirm:
+          </Label>
+          <Input
+            id="confirmDeleteName"
+            value={confirmName}
+            onChange={(e) => setConfirmName(e.target.value)}
+            placeholder={project?.name ?? ""}
+            className="border-destructive/25 focus-visible:ring-destructive/20"
+            disabled={isDeleting}
+          />
+        </div>
         <AlertDialogFooter>
           <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
           <Button
             variant="destructive"
             onClick={handleDelete}
-            disabled={isDeleting}
+            disabled={isDeleting || confirmName !== (project?.name ?? "")}
             className="focus-visible:ring-destructive/20"
           >
             {isDeleting ? (

--- a/components/edit-project-dialog.tsx
+++ b/components/edit-project-dialog.tsx
@@ -1,7 +1,8 @@
 "use client"
 
-import { Loader2, Save } from "lucide-react"
+import { Folder, FolderOpen, Loader2, Save } from "lucide-react"
 import { useEffect, useState, useTransition } from "react"
+import { useQuery } from "convex/react"
 import { toast } from "sonner"
 import { updateProjectInConfigAction } from "@/app/dashboard/[owner]/[repo]/config-actions"
 import { Button } from "./ui/button"
@@ -9,6 +10,9 @@ import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, D
 import { Input } from "./ui/input"
 import { Label } from "./ui/label"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "./ui/select"
+import type { Id } from "@/convex/_generated/dataModel"
+import { api } from "@/convex/_generated/api"
+import { FolderPickerDialog } from "./folder-picker-dialog"
 
 const FRAMEWORK_OPTIONS = [
   { value: "auto", label: "Auto-detect" },
@@ -66,6 +70,8 @@ export function EditProjectDialog({
   const [contentType, setContentType] = useState("custom")
   const [branch, setBranch] = useState("")
   const [error, setError] = useState<string | null>(null)
+  const [contentRoot, setContentRoot] = useState("")
+  const [folderPickerOpen, setFolderPickerOpen] = useState(false)
 
   // Sync form state when project changes
   const resetToProject = (p: EditableProject) => {
@@ -73,6 +79,8 @@ export function EditProjectDialog({
     setFramework(p.detectedFramework || "auto")
     setContentType(p.contentType)
     setBranch(p.branch === defaultBranch ? "" : p.branch)
+    setContentRoot(p.contentRoot)
+    setFolderPickerOpen(false)
     setError(null)
   }
 
@@ -88,6 +96,11 @@ export function EditProjectDialog({
     if (!o) setError(null)
     onOpenChange(o)
   }
+
+  const hasContent = useQuery(
+    api.documents.hasContentForProject,
+    project ? { projectId: project._id as Id<"projects"> } : "skip",
+  )
 
   if (!project) return null
 
@@ -112,6 +125,7 @@ export function EditProjectDialog({
         framework,
         contentType: contentType as "blog" | "docs" | "pages" | "changelog" | "custom",
         ...(branch.trim() ? { branch: branch.trim() } : {}),
+        ...(contentRoot !== project.contentRoot ? { contentRoot } : {}),
       })
 
       if (result.success) {
@@ -157,11 +171,52 @@ export function EditProjectDialog({
 
           <div className="grid gap-2">
             <Label>Content Root</Label>
-            <Input value={project.contentRoot || "(repo root)"} disabled className="bg-muted" />
-            <p className="text-xs text-muted-foreground">
-              Content root cannot be changed after creation. To use a different path, remove this project and add a new
-              one.
-            </p>
+            {hasContent === false ? (
+              <>
+                <div className="flex gap-2">
+                  <div className="relative flex-1">
+                    <Folder className="absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
+                    <Input
+                      readOnly
+                      value={contentRoot || "(repo root)"}
+                      onClick={() => !isPending && setFolderPickerOpen(true)}
+                      className="pl-9 cursor-pointer"
+                      disabled={isPending || !isConfigManaged}
+                    />
+                  </div>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="icon"
+                    onClick={() => setFolderPickerOpen(true)}
+                    disabled={isPending || !isConfigManaged}
+                    title="Browse directories"
+                  >
+                    <FolderOpen className="h-4 w-4" />
+                  </Button>
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  No content exists yet — you can change the content root.
+                </p>
+                <FolderPickerDialog
+                  open={folderPickerOpen}
+                  onOpenChange={setFolderPickerOpen}
+                  onSelect={(path) => setContentRoot(path)}
+                  owner={owner}
+                  repo={repo}
+                  branch={project.branch || defaultBranch}
+                  initialPath={contentRoot}
+                />
+              </>
+            ) : (
+              <>
+                <Input value={project.contentRoot || "(repo root)"} disabled className="bg-muted" />
+                <p className="text-xs text-muted-foreground">
+                  Content root cannot be changed because this project has existing documents. Delete all content first,
+                  or create a new project with a different root.
+                </p>
+              </>
+            )}
           </div>
 
           <div className="grid grid-cols-2 gap-4">

--- a/components/edit-project-dialog.tsx
+++ b/components/edit-project-dialog.tsx
@@ -1,18 +1,18 @@
 "use client"
 
-import { Folder, FolderOpen, Loader2, Save } from "lucide-react"
-import { useEffect, useState, useTransition } from "react"
 import { useQuery } from "convex/react"
+import { Folder, FolderOpen, Loader2, Save } from "lucide-react"
+import { useCallback, useEffect, useState, useTransition } from "react"
 import { toast } from "sonner"
 import { updateProjectInConfigAction } from "@/app/dashboard/[owner]/[repo]/config-actions"
+import { api } from "@/convex/_generated/api"
+import type { Id } from "@/convex/_generated/dataModel"
+import { FolderPickerDialog } from "./folder-picker-dialog"
 import { Button } from "./ui/button"
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "./ui/dialog"
 import { Input } from "./ui/input"
 import { Label } from "./ui/label"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "./ui/select"
-import type { Id } from "@/convex/_generated/dataModel"
-import { api } from "@/convex/_generated/api"
-import { FolderPickerDialog } from "./folder-picker-dialog"
 
 const FRAMEWORK_OPTIONS = [
   { value: "auto", label: "Auto-detect" },
@@ -43,6 +43,7 @@ export interface EditableProject {
   contentType: string
   branch: string
   configProjectId?: string
+  projectAccessToken?: string
 }
 
 interface EditProjectDialogProps {
@@ -74,23 +75,25 @@ export function EditProjectDialog({
   const [folderPickerOpen, setFolderPickerOpen] = useState(false)
 
   // Sync form state when project changes
-  const resetToProject = (p: EditableProject) => {
-    setName(p.name)
-    setFramework(p.detectedFramework || "auto")
-    setContentType(p.contentType)
-    setBranch(p.branch === defaultBranch ? "" : p.branch)
-    setContentRoot(p.contentRoot)
-    setFolderPickerOpen(false)
-    setError(null)
-  }
+  const resetToProject = useCallback(
+    (p: EditableProject) => {
+      setName(p.name)
+      setFramework(p.detectedFramework || "auto")
+      setContentType(p.contentType)
+      setBranch(p.branch === defaultBranch ? "" : p.branch)
+      setContentRoot(p.contentRoot)
+      setFolderPickerOpen(false)
+      setError(null)
+    },
+    [defaultBranch],
+  )
 
   // Reset form when dialog opens or project identity changes.
   // Radix controlled Dialog does NOT call onOpenChange(true) when the parent
   // sets open=true, so we must use useEffect instead of relying on handleOpenChange.
   useEffect(() => {
     if (open && project) resetToProject(project)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open, project?._id])
+  }, [open, project, resetToProject])
 
   const handleOpenChange = (o: boolean) => {
     if (!o) setError(null)
@@ -99,7 +102,12 @@ export function EditProjectDialog({
 
   const hasContent = useQuery(
     api.documents.hasContentForProject,
-    project ? { projectId: project._id as Id<"projects"> } : "skip",
+    project
+      ? {
+          projectId: project._id as Id<"projects">,
+          projectAccessToken: project.projectAccessToken || undefined,
+        }
+      : "skip",
   )
 
   if (!project) return null

--- a/components/folder-picker-dialog.tsx
+++ b/components/folder-picker-dialog.tsx
@@ -1,0 +1,318 @@
+"use client"
+
+import { ChevronRight, Folder, FolderOpen, Loader2, AlertCircle } from "lucide-react"
+import { useCallback, useEffect, useState } from "react"
+import { fetchRepoDirsAction } from "@/app/dashboard/[owner]/[repo]/actions"
+import { Button } from "./ui/button"
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "./ui/dialog"
+import { ScrollArea } from "./ui/scroll-area"
+import { cn } from "@/lib/utils"
+
+type FolderNode = {
+  name: string
+  path: string // full repo-relative path (e.g. "content/docs")
+  children: FolderNode[] | null // null = not yet loaded
+  isLoading: boolean
+  error: string | null
+}
+
+interface FolderPickerDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onSelect: (path: string) => void
+  owner: string
+  repo: string
+  branch: string
+  initialPath?: string // pre-selected path when dialog opens
+}
+
+export function FolderPickerDialog({
+  open,
+  onOpenChange,
+  onSelect,
+  owner,
+  repo,
+  branch,
+  initialPath = "",
+}: FolderPickerDialogProps) {
+  const [tree, setTree] = useState<FolderNode[]>([])
+  const [selectedPath, setSelectedPath] = useState<string>(initialPath)
+  const [isLoadingRoot, setIsLoadingRoot] = useState(false)
+  const [rootError, setRootError] = useState<string | null>(null)
+  const [expandedPaths, setExpandedPaths] = useState<Set<string>>(new Set())
+
+  // Load root directories when dialog opens
+  useEffect(() => {
+    if (!open) return
+    setSelectedPath(initialPath ?? "")
+    setIsLoadingRoot(true)
+    setRootError(null)
+
+    fetchRepoDirsAction(owner, repo, "", branch).then((result) => {
+      setIsLoadingRoot(false)
+      if (result.success) {
+        setTree(
+          result.dirs.map((d) => ({
+            name: d.name,
+            path: d.path,
+            children: null,
+            isLoading: false,
+            error: null,
+          })),
+        )
+      } else {
+        setRootError(result.error)
+        setTree([])
+      }
+    })
+  }, [open, owner, repo, branch])
+  // Note: intentionally excluding initialPath from deps to avoid re-fetching on path change
+
+  const loadChildren = useCallback(
+    async (path: string) => {
+      // Mark node as loading
+      setTree((prev) => updateNodeInTree(prev, path, { isLoading: true, error: null }))
+
+      const result = await fetchRepoDirsAction(owner, repo, path, branch)
+
+      if (result.success) {
+        setTree((prev) =>
+          updateNodeInTree(prev, path, {
+            isLoading: false,
+            children: result.dirs.map((d) => ({
+              name: d.name,
+              path: d.path,
+              children: null,
+              isLoading: false,
+              error: null,
+            })),
+          }),
+        )
+      } else {
+        setTree((prev) =>
+          updateNodeInTree(prev, path, {
+            isLoading: false,
+            error: result.error,
+          }),
+        )
+      }
+    },
+    [owner, repo, branch],
+  )
+
+  const handleToggle = (node: FolderNode) => {
+    if (node.children !== null) {
+      // Children already loaded — toggle expanded state
+      setExpandedPaths((prev) => {
+        const next = new Set(prev)
+        if (next.has(node.path)) {
+          next.delete(node.path)
+        } else {
+          next.add(node.path)
+        }
+        return next
+      })
+    } else {
+      // First expand: load children
+      setExpandedPaths((prev) => new Set(prev).add(node.path))
+      loadChildren(node.path)
+    }
+  }
+
+  const handleConfirm = () => {
+    onSelect(selectedPath)
+    onOpenChange(false)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Select Content Root</DialogTitle>
+          <DialogDescription>
+            Browse directories in {owner}/{repo} to select the content root folder.
+          </DialogDescription>
+        </DialogHeader>
+
+        <ScrollArea className="h-[300px] rounded-md border p-2">
+          {/* Repo root option — always present */}
+          <button
+            type="button"
+            className={cn(
+              "flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-accent",
+              selectedPath === "" && "bg-accent text-accent-foreground font-medium",
+            )}
+            onClick={() => setSelectedPath("")}
+          >
+            <Folder className="h-4 w-4 text-muted-foreground" />
+            <span>(repo root)</span>
+          </button>
+
+          {isLoadingRoot ? (
+            <div className="flex items-center justify-center py-8">
+              <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+            </div>
+          ) : rootError ? (
+            <div className="flex flex-col items-center gap-2 py-8 text-sm text-destructive">
+              <AlertCircle className="h-5 w-5" />
+              <p>{rootError}</p>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => {
+                  setIsLoadingRoot(true)
+                  setRootError(null)
+                  fetchRepoDirsAction(owner, repo, "", branch).then((result) => {
+                    setIsLoadingRoot(false)
+                    if (result.success) {
+                      setTree(
+                        result.dirs.map((d) => ({
+                          name: d.name,
+                          path: d.path,
+                          children: null,
+                          isLoading: false,
+                          error: null,
+                        })),
+                      )
+                    } else {
+                      setRootError(result.error)
+                    }
+                  })
+                }}
+              >
+                Retry
+              </Button>
+            </div>
+          ) : (
+            <FolderTreeNodes
+              nodes={tree}
+              depth={0}
+              selectedPath={selectedPath}
+              expandedPaths={expandedPaths}
+              onSelect={setSelectedPath}
+              onToggle={handleToggle}
+            />
+          )}
+        </ScrollArea>
+
+        <div className="text-sm text-muted-foreground">
+          Selected: <code className="bg-muted px-1.5 py-0.5 rounded text-xs">{selectedPath || "(repo root)"}</code>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button onClick={handleConfirm}>Confirm</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+// --- Internal helper components and functions ---
+
+function FolderTreeNodes({
+  nodes,
+  depth,
+  selectedPath,
+  expandedPaths,
+  onSelect,
+  onToggle,
+}: {
+  nodes: FolderNode[]
+  depth: number
+  selectedPath: string
+  expandedPaths: Set<string>
+  onSelect: (path: string) => void
+  onToggle: (node: FolderNode) => void
+}) {
+  if (nodes.length === 0) {
+    return (
+      <p className="text-xs text-muted-foreground py-1" style={{ paddingLeft: `${(depth + 1) * 16 + 8}px` }}>
+        No subfolders
+      </p>
+    )
+  }
+
+  return (
+    <>
+      {nodes.map((node) => {
+        const isExpanded = expandedPaths.has(node.path)
+        const isSelected = selectedPath === node.path
+        return (
+          <div key={node.path}>
+            <div
+              className={cn(
+                "flex items-center gap-1 rounded-md px-1 py-1 text-sm hover:bg-accent cursor-pointer",
+                isSelected && "bg-accent text-accent-foreground font-medium",
+              )}
+              style={{ paddingLeft: `${depth * 16 + 4}px` }}
+            >
+              <button
+                type="button"
+                className="p-0.5 hover:bg-muted rounded"
+                onClick={(e) => {
+                  e.stopPropagation()
+                  onToggle(node)
+                }}
+              >
+                {node.isLoading ? (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />
+                ) : (
+                  <ChevronRight
+                    className={cn("h-3.5 w-3.5 text-muted-foreground transition-transform", isExpanded && "rotate-90")}
+                  />
+                )}
+              </button>
+              <button
+                type="button"
+                className="flex items-center gap-1.5 flex-1 text-left"
+                onClick={() => onSelect(node.path)}
+              >
+                {isExpanded ? (
+                  <FolderOpen className="h-4 w-4 text-muted-foreground" />
+                ) : (
+                  <Folder className="h-4 w-4 text-muted-foreground" />
+                )}
+                <span>{node.name}</span>
+              </button>
+            </div>
+
+            {node.error && (
+              <p className="text-xs text-destructive py-1" style={{ paddingLeft: `${(depth + 1) * 16 + 8}px` }}>
+                {node.error}
+              </p>
+            )}
+
+            {isExpanded && node.children !== null && (
+              <FolderTreeNodes
+                nodes={node.children}
+                depth={depth + 1}
+                selectedPath={selectedPath}
+                expandedPaths={expandedPaths}
+                onSelect={onSelect}
+                onToggle={onToggle}
+              />
+            )}
+          </div>
+        )
+      })}
+    </>
+  )
+}
+
+function updateNodeInTree(nodes: FolderNode[], targetPath: string, updates: Partial<FolderNode>): FolderNode[] {
+  return nodes.map((node) => {
+    if (node.path === targetPath) {
+      return { ...node, ...updates }
+    }
+    if (node.children && targetPath.startsWith(node.path + "/")) {
+      return {
+        ...node,
+        children: updateNodeInTree(node.children, targetPath, updates),
+      }
+    }
+    return node
+  })
+}

--- a/components/folder-picker-dialog.tsx
+++ b/components/folder-picker-dialog.tsx
@@ -1,12 +1,12 @@
 "use client"
 
-import { ChevronRight, Folder, FolderOpen, Loader2, AlertCircle } from "lucide-react"
+import { AlertCircle, Folder, Loader2 } from "lucide-react"
 import { useCallback, useEffect, useState } from "react"
 import { fetchRepoDirsAction } from "@/app/dashboard/[owner]/[repo]/actions"
 import { Button } from "./ui/button"
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "./ui/dialog"
 import { ScrollArea } from "./ui/scroll-area"
-import { cn } from "@/lib/utils"
+import { Tree, TreeItem, TreeProvider } from "./ui/tree"
 
 type FolderNode = {
   name: string
@@ -39,9 +39,9 @@ export function FolderPickerDialog({
   const [selectedPath, setSelectedPath] = useState<string>(initialPath)
   const [isLoadingRoot, setIsLoadingRoot] = useState(false)
   const [rootError, setRootError] = useState<string | null>(null)
-  const [expandedPaths, setExpandedPaths] = useState<Set<string>>(new Set())
 
   // Load root directories when dialog opens
+  // biome-ignore lint/correctness/useExhaustiveDependencies: intentionally excluding initialPath to avoid re-fetching on path change
   useEffect(() => {
     if (!open) return
     setSelectedPath(initialPath ?? "")
@@ -66,11 +66,9 @@ export function FolderPickerDialog({
       }
     })
   }, [open, owner, repo, branch])
-  // Note: intentionally excluding initialPath from deps to avoid re-fetching on path change
 
   const loadChildren = useCallback(
     async (path: string) => {
-      // Mark node as loading
       setTree((prev) => updateNodeInTree(prev, path, { isLoading: true, error: null }))
 
       const result = await fetchRepoDirsAction(owner, repo, path, branch)
@@ -100,24 +98,16 @@ export function FolderPickerDialog({
     [owner, repo, branch],
   )
 
-  const handleToggle = (node: FolderNode) => {
-    if (node.children !== null) {
-      // Children already loaded — toggle expanded state
-      setExpandedPaths((prev) => {
-        const next = new Set(prev)
-        if (next.has(node.path)) {
-          next.delete(node.path)
-        } else {
-          next.add(node.path)
-        }
-        return next
-      })
-    } else {
-      // First expand: load children
-      setExpandedPaths((prev) => new Set(prev).add(node.path))
-      loadChildren(node.path)
-    }
-  }
+  const handleNodeExpand = useCallback(
+    (nodeId: string, expanded: boolean) => {
+      if (!expanded || nodeId === "") return
+      const node = findNodeInTree(tree, nodeId)
+      if (node && node.children === null) {
+        loadChildren(nodeId)
+      }
+    },
+    [tree, loadChildren],
+  )
 
   const handleConfirm = () => {
     onSelect(selectedPath)
@@ -134,20 +124,7 @@ export function FolderPickerDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <ScrollArea className="h-[300px] rounded-md border p-2">
-          {/* Repo root option — always present */}
-          <button
-            type="button"
-            className={cn(
-              "flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-accent",
-              selectedPath === "" && "bg-accent text-accent-foreground font-medium",
-            )}
-            onClick={() => setSelectedPath("")}
-          >
-            <Folder className="h-4 w-4 text-muted-foreground" />
-            <span>(repo root)</span>
-          </button>
-
+        <ScrollArea className="h-[300px] rounded-md border">
           {isLoadingRoot ? (
             <div className="flex items-center justify-center py-8">
               <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
@@ -184,14 +161,37 @@ export function FolderPickerDialog({
               </Button>
             </div>
           ) : (
-            <FolderTreeNodes
-              nodes={tree}
-              depth={0}
-              selectedPath={selectedPath}
-              expandedPaths={expandedPaths}
-              onSelect={setSelectedPath}
-              onToggle={handleToggle}
-            />
+            <TreeProvider
+              variant="ghost"
+              className="!border-0 !shadow-none !rounded-none"
+              selectedIds={[selectedPath]}
+              onSelectionChange={(ids) => setSelectedPath(ids[0] ?? "")}
+              onNodeExpand={handleNodeExpand}
+              showLines
+              showIcons
+              indent={16}
+              animateExpand
+            >
+              <Tree>
+                {/* Repo root — always present */}
+                <TreeItem
+                  nodeId=""
+                  label="(repo root)"
+                  icon={<Folder className="h-4 w-4" />}
+                  hasChildren={false}
+                  level={0}
+                />
+                {tree.map((node, i) => (
+                  <FolderNodeTreeItem
+                    key={node.path}
+                    node={node}
+                    level={0}
+                    isLast={i === tree.length - 1}
+                    parentPath={[]}
+                  />
+                ))}
+              </Tree>
+            </TreeProvider>
           )}
         </ScrollArea>
 
@@ -210,96 +210,70 @@ export function FolderPickerDialog({
   )
 }
 
-// --- Internal helper components and functions ---
+// --- Recursive tree item for folder nodes ---
 
-function FolderTreeNodes({
-  nodes,
-  depth,
-  selectedPath,
-  expandedPaths,
-  onSelect,
-  onToggle,
+function FolderNodeTreeItem({
+  node,
+  level,
+  isLast,
+  parentPath,
 }: {
-  nodes: FolderNode[]
-  depth: number
-  selectedPath: string
-  expandedPaths: Set<string>
-  onSelect: (path: string) => void
-  onToggle: (node: FolderNode) => void
+  node: FolderNode
+  level: number
+  isLast: boolean
+  parentPath: boolean[]
 }) {
-  if (nodes.length === 0) {
-    return (
-      <p className="text-xs text-muted-foreground py-1" style={{ paddingLeft: `${(depth + 1) * 16 + 8}px` }}>
-        No subfolders
-      </p>
-    )
-  }
+  const hasChildren = node.children === null || node.children.length > 0
+  const currentPath = [...parentPath, isLast]
 
   return (
-    <>
-      {nodes.map((node) => {
-        const isExpanded = expandedPaths.has(node.path)
-        const isSelected = selectedPath === node.path
-        return (
-          <div key={node.path}>
-            <div
-              className={cn(
-                "flex items-center gap-1 rounded-md px-1 py-1 text-sm hover:bg-accent cursor-pointer",
-                isSelected && "bg-accent text-accent-foreground font-medium",
-              )}
-              style={{ paddingLeft: `${depth * 16 + 4}px` }}
-            >
-              <button
-                type="button"
-                className="p-0.5 hover:bg-muted rounded"
-                onClick={(e) => {
-                  e.stopPropagation()
-                  onToggle(node)
-                }}
-              >
-                {node.isLoading ? (
-                  <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />
-                ) : (
-                  <ChevronRight
-                    className={cn("h-3.5 w-3.5 text-muted-foreground transition-transform", isExpanded && "rotate-90")}
-                  />
-                )}
-              </button>
-              <button
-                type="button"
-                className="flex items-center gap-1.5 flex-1 text-left"
-                onClick={() => onSelect(node.path)}
-              >
-                {isExpanded ? (
-                  <FolderOpen className="h-4 w-4 text-muted-foreground" />
-                ) : (
-                  <Folder className="h-4 w-4 text-muted-foreground" />
-                )}
-                <span>{node.name}</span>
-              </button>
-            </div>
-
-            {node.error && (
-              <p className="text-xs text-destructive py-1" style={{ paddingLeft: `${(depth + 1) * 16 + 8}px` }}>
-                {node.error}
-              </p>
-            )}
-
-            {isExpanded && node.children !== null && (
-              <FolderTreeNodes
-                nodes={node.children}
-                depth={depth + 1}
-                selectedPath={selectedPath}
-                expandedPaths={expandedPaths}
-                onSelect={onSelect}
-                onToggle={onToggle}
-              />
-            )}
-          </div>
-        )
-      })}
-    </>
+    <TreeItem
+      nodeId={node.path}
+      label={node.name}
+      level={level}
+      isLast={isLast}
+      parentPath={parentPath}
+      hasChildren={hasChildren}
+      icon={<Folder className="h-4 w-4" />}
+    >
+      {node.isLoading ? (
+        <div className="flex items-center py-1" style={{ paddingLeft: `${(level + 1) * 16 + 28}px` }}>
+          <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />
+        </div>
+      ) : node.error ? (
+        <p className="text-xs text-destructive py-1" style={{ paddingLeft: `${(level + 1) * 16 + 28}px` }}>
+          {node.error}
+        </p>
+      ) : node.children && node.children.length === 0 ? (
+        <p className="text-xs text-muted-foreground py-1" style={{ paddingLeft: `${(level + 1) * 16 + 28}px` }}>
+          No subfolders
+        </p>
+      ) : node.children ? (
+        node.children.map((child, i) => (
+          <FolderNodeTreeItem
+            key={child.path}
+            node={child}
+            level={level + 1}
+            isLast={i === node.children!.length - 1}
+            parentPath={currentPath}
+          />
+        ))
+      ) : null}
+    </TreeItem>
   )
+}
+
+// --- Utility helpers ---
+
+function findNodeInTree(nodes: FolderNode[], targetPath: string): FolderNode | null {
+  for (const node of nodes) {
+    if (node.path === targetPath) return node
+    if (node.children) {
+      const found = findNodeInTree(node.children, targetPath)
+      if (found) return found
+    }
+  }
+  return null
 }
 
 function updateNodeInTree(nodes: FolderNode[], targetPath: string, updates: Partial<FolderNode>): FolderNode[] {
@@ -307,7 +281,7 @@ function updateNodeInTree(nodes: FolderNode[], targetPath: string, updates: Part
     if (node.path === targetPath) {
       return { ...node, ...updates }
     }
-    if (node.children && targetPath.startsWith(node.path + "/")) {
+    if (node.children && targetPath.startsWith(`${node.path}/`)) {
       return {
         ...node,
         children: updateNodeInTree(node.children, targetPath, updates),

--- a/components/remove-project-dialog.tsx
+++ b/components/remove-project-dialog.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { AlertTriangle, Loader2, Trash2 } from "lucide-react"
-import { useState, useTransition } from "react"
+import { useEffect, useState, useTransition } from "react"
 import { toast } from "sonner"
 import { removeProjectFromConfigAction } from "@/app/dashboard/[owner]/[repo]/config-actions"
 import { Button } from "./ui/button"
@@ -40,6 +40,15 @@ export function RemoveProjectDialog({
   const [confirmText, setConfirmText] = useState("")
   const [error, setError] = useState<string | null>(null)
 
+  // Reset form state whenever the dialog closes, regardless of how it was closed
+  // (Cancel button, Escape key, overlay click, or programmatic close after success).
+  useEffect(() => {
+    if (!open) {
+      setConfirmText("")
+      setError(null)
+    }
+  }, [open])
+
   if (!project) return null
 
   const isConfigManaged = project.frameworkSource === "config" && !!project.configProjectId
@@ -62,7 +71,6 @@ export function RemoveProjectDialog({
 
       if (result.success) {
         toast.success(`Project "${project.name}" removed from config`)
-        setConfirmText("")
         onOpenChange(false)
         onSuccess?.()
       } else {
@@ -73,16 +81,7 @@ export function RemoveProjectDialog({
   }
 
   return (
-    <Dialog
-      open={open}
-      onOpenChange={(o) => {
-        if (!o) {
-          setConfirmText("")
-          setError(null)
-        }
-        onOpenChange(o)
-      }}
-    >
+    <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
         className="sm:max-w-md"
         // Same Radix aria-hidden race fix as EditProjectDialog — see that file for details.
@@ -122,7 +121,16 @@ export function RemoveProjectDialog({
 
             <div className="grid gap-2">
               <Label htmlFor="confirm-remove">
-                Type <strong>{project.name}</strong> to confirm
+                Type{" "}
+                <button
+                  type="button"
+                  className="inline font-bold cursor-pointer hover:underline bg-transparent border-0 p-0 text-inherit"
+                  title="Click to fill"
+                  onClick={() => setConfirmText(project.name)}
+                >
+                  {project.name}
+                </button>{" "}
+                to confirm
               </Label>
               <Input
                 id="confirm-remove"

--- a/components/repo-project-hub.tsx
+++ b/components/repo-project-hub.tsx
@@ -65,6 +65,7 @@ interface RepoProjectHubProps {
   configJson: string | null
   configSha: string | null
   actingUserId?: string | null
+  projectAccessTokens?: Record<string, string>
 }
 
 export function RepoProjectHub({
@@ -81,6 +82,7 @@ export function RepoProjectHub({
   configJson,
   configSha,
   actingUserId,
+  projectAccessTokens,
 }: RepoProjectHubProps) {
   const router = useRouter()
   const [isPending, startTransition] = useTransition()
@@ -270,6 +272,7 @@ export function RepoProjectHub({
                                       contentType: project.contentType,
                                       branch: project.branch,
                                       configProjectId: project.configProjectId,
+                                      projectAccessToken: projectAccessTokens?.[project._id],
                                     }),
                                   0,
                                 )

--- a/components/repo-setup-form.tsx
+++ b/components/repo-setup-form.tsx
@@ -1,7 +1,17 @@
 "use client"
 
 import { useMutation, useQuery } from "convex/react"
-import { AlertCircle, CheckCircle2, Folder, GitBranch, Loader2, RefreshCw, Settings, Sparkles } from "lucide-react"
+import {
+  AlertCircle,
+  CheckCircle2,
+  Folder,
+  FolderOpen,
+  GitBranch,
+  Loader2,
+  RefreshCw,
+  Settings,
+  Sparkles,
+} from "lucide-react"
 import { useRouter } from "next/navigation"
 import type React from "react"
 import { useState, useTransition } from "react"
@@ -19,6 +29,7 @@ import type { RepoPressConfig } from "@/lib/config-schema"
 import { getFrameworkConfig, getRegisteredAdapters } from "@/lib/framework-adapters"
 import type { ConfigErrorType } from "@/lib/repopress/config"
 import { retrySyncAction } from "@/lib/sync-projects"
+import { FolderPickerDialog } from "./folder-picker-dialog"
 
 interface RepoSetupFormProps {
   owner: string
@@ -66,6 +77,7 @@ export function RepoSetupForm({
   const [isLoading, setIsLoading] = useState(false)
   const [isInitializing, setIsInitializing] = useState(false)
   const [showAdvanced, setShowAdvanced] = useState(false)
+  const [folderPickerOpen, setFolderPickerOpen] = useState(false)
   const [isSyncPending, startSyncTransition] = useTransition()
 
   const registeredAdapters = getRegisteredAdapters()
@@ -342,15 +354,37 @@ export function RepoSetupForm({
 
           <div className="space-y-2">
             <Label>Content Root</Label>
-            <div className="relative">
-              <Folder className="absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
-              <Input
-                placeholder="e.g. content/blog"
-                value={contentPath}
-                onChange={(e) => setContentPath(e.target.value)}
-                className="pl-9"
-              />
+            <div className="flex gap-2">
+              <div className="relative flex-1">
+                <Folder className="absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
+                <Input
+                  readOnly
+                  value={contentPath || "(repo root)"}
+                  onClick={() => setFolderPickerOpen(true)}
+                  className="pl-9 cursor-pointer"
+                  placeholder="Click to browse..."
+                />
+              </div>
+              <Button
+                type="button"
+                variant="outline"
+                size="icon"
+                onClick={() => setFolderPickerOpen(true)}
+                title="Browse directories"
+              >
+                <FolderOpen className="h-4 w-4" />
+              </Button>
             </div>
+
+            <FolderPickerDialog
+              open={folderPickerOpen}
+              onOpenChange={setFolderPickerOpen}
+              onSelect={(path) => setContentPath(path)}
+              owner={owner}
+              repo={repo}
+              branch={selectedBranch}
+              initialPath={contentPath}
+            />
             {(() => {
               const config = getFrameworkConfig(selectedFramework)
               const roots = config.suggestedContentRoots

--- a/components/settings/delete-project-zone.tsx
+++ b/components/settings/delete-project-zone.tsx
@@ -85,7 +85,11 @@ export function DeleteProjectZone({ project, projectAccessToken }: DeleteProject
           </Alert>
         )}
 
-        <AlertDialog>
+        <AlertDialog
+          onOpenChange={(o) => {
+            if (!o) setConfirmName("")
+          }}
+        >
           <AlertDialogTrigger asChild>
             <Button variant="destructive" className="w-full sm:w-auto">
               <Trash2 className="h-4 w-4 mr-2" />
@@ -96,14 +100,31 @@ export function DeleteProjectZone({ project, projectAccessToken }: DeleteProject
             <AlertDialogHeader>
               <AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>
               <AlertDialogDescription>
-                This will delete the <strong>{project.name}</strong> project and all its associated data. This action is
-                irreversible.
+                This will delete the{" "}
+                <button
+                  type="button"
+                  className="inline font-bold text-foreground cursor-pointer hover:underline bg-transparent border-0 p-0 text-inherit"
+                  title="Click to fill"
+                  onClick={() => setConfirmName(project.name)}
+                >
+                  {project.name}
+                </button>{" "}
+                project and all its associated data. This action is irreversible.
               </AlertDialogDescription>
             </AlertDialogHeader>
 
             <div className="my-4 space-y-2">
               <Label htmlFor="confirmName" className="text-sm">
-                Type <span className="font-mono font-bold text-foreground">{project.name}</span> to confirm:
+                Type{" "}
+                <button
+                  type="button"
+                  className="inline font-mono font-bold text-foreground cursor-pointer hover:underline bg-transparent border-0 p-0 text-sm"
+                  title="Click to fill"
+                  onClick={() => setConfirmName(project.name)}
+                >
+                  {project.name}
+                </button>{" "}
+                to confirm:
               </Label>
               <Input
                 id="confirmName"
@@ -117,9 +138,9 @@ export function DeleteProjectZone({ project, projectAccessToken }: DeleteProject
             <AlertDialogFooter>
               <AlertDialogCancel onClick={() => setConfirmName("")}>Cancel</AlertDialogCancel>
               <AlertDialogAction
+                variant="destructive"
                 onClick={handleDelete}
                 disabled={confirmName !== project.name || isDeleting}
-                className="bg-destructive text-destructive-foreground hover:bg-destructive/90 focus-visible:ring-destructive/20"
               >
                 {isDeleting ? "Deleting..." : "Yes, Delete Project"}
               </AlertDialogAction>

--- a/components/studio/hooks/use-studio-file.ts
+++ b/components/studio/hooks/use-studio-file.ts
@@ -356,6 +356,10 @@ export function useStudioFile(initialFile: InitialFile | null | undefined, curre
 
     if (!openFilesHydrated) return
 
+    // Don't validate open files against an empty tree — the real tree is still loading client-side.
+    // Filtering against [] would wipe all open tabs and overwrite localStorage before tree arrives.
+    if (tree.length === 0) return
+
     // Use functional updater to avoid including openFiles in deps (prevents double-execution)
     let restoreTarget: string | undefined
     setOpenFiles((prev) => {

--- a/components/studio/studio-layout.tsx
+++ b/components/studio/studio-layout.tsx
@@ -1818,8 +1818,9 @@ function StudioProviderWrapper(props: StudioLayoutProps) {
   const studioFile = useStudioFile(initialFile, currentPath)
   const { selectedFile } = studioFile
 
-  // 2. Queries hook
-  const studioQueries = useStudioQueries(selectedFile?.path)
+  // 2. Queries hook — pass the local tree state so overlayTree uses the async-fetched
+  // tree rather than the outer StudioProvider's empty initialTree.
+  const studioQueries = useStudioQueries(selectedFile?.path, { tree })
   const {
     previewEntry,
     enabledPlugins,

--- a/components/studio/studio-layout.tsx
+++ b/components/studio/studio-layout.tsx
@@ -1795,11 +1795,24 @@ function StudioProviderWrapper(props: StudioLayoutProps) {
     projectId,
     projectAccessToken,
     contentRoot = "",
-    tree,
+    tree: initialTree,
     initialFile,
     currentPath,
     role = "owner",
   } = props
+
+  // Tree starts from the server-provided value ([] when server deferred loading).
+  // A client-side fetch runs immediately when the initial tree is empty, unblocking
+  // the server render from the expensive GitHub recursive-tree API call.
+  const [tree, setTree] = React.useState<FileTreeNode[]>(initialTree)
+  React.useEffect(() => {
+    if (initialTree.length > 0) return
+    const qp = new URLSearchParams({ owner, repo, branch: branch ?? "main", contentRoot })
+    fetch(`/api/github/tree?${qp}`)
+      .then((res) => (res.ok ? res.json() : Promise.reject(res)))
+      .then((data: FileTreeNode[]) => setTree(data))
+      .catch(() => {}) // non-critical: empty tree is an acceptable fallback
+  }, [owner, repo, branch, contentRoot, initialTree.length])
 
   // 1. File state hook
   const studioFile = useStudioFile(initialFile, currentPath)

--- a/components/ui/tree.tsx
+++ b/components/ui/tree.tsx
@@ -1,0 +1,373 @@
+"use client"
+
+import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
+import { cva, type VariantProps } from "class-variance-authority"
+import { ChevronRight, Folder, File, FolderOpen } from "lucide-react"
+import { motion, AnimatePresence } from "motion/react"
+import { cn } from "@/lib/utils"
+
+// Tree Context
+interface TreeContextType {
+  expandedIds: Set<string>
+  selectedIds: string[]
+  toggleExpanded: (nodeId: string) => void
+  handleSelection: (nodeId: string, ctrlKey?: boolean) => void
+  showLines: boolean
+  showIcons: boolean
+  selectable: boolean
+  multiSelect: boolean
+  animateExpand: boolean
+  indent: number
+  onNodeClick?: (nodeId: string, data?: any) => void
+  onNodeExpand?: (nodeId: string, expanded: boolean) => void
+}
+
+const TreeContext = React.createContext<TreeContextType | null>(null)
+
+const useTree = () => {
+  const context = React.useContext(TreeContext)
+  if (!context) {
+    throw new Error("Tree components must be used within a TreeProvider")
+  }
+  return context
+}
+
+// Tree variants
+const treeVariants = cva("w-full bg-background border border-border rounded-ele shadow-sm/2", {
+  variants: {
+    variant: {
+      default: "",
+      outline: "border-2",
+      ghost: "border-transparent bg-transparent",
+    },
+    size: {
+      sm: "text-sm",
+      default: "",
+      lg: "text-lg",
+    },
+  },
+  defaultVariants: {
+    variant: "default",
+    size: "default",
+  },
+})
+
+const treeItemVariants = cva(
+  "flex items-center py-2 px-3 cursor-pointer transition-all duration-200 relative group rounded-[calc(var(--card-radius)-8px)]",
+  {
+    variants: {
+      variant: {
+        default: "hover:bg-accent focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none",
+        ghost: "hover:bg-accent/50",
+        subtle: "hover:bg-muted/50",
+      },
+      selected: {
+        true: "bg-accent text-accent-foreground",
+        false: "",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      selected: false,
+    },
+  },
+)
+
+// Provider Props
+export interface TreeProviderProps extends React.HTMLAttributes<HTMLDivElement>, VariantProps<typeof treeVariants> {
+  defaultExpandedIds?: string[]
+  selectedIds?: string[]
+  onSelectionChange?: (selectedIds: string[]) => void
+  onNodeClick?: (nodeId: string, data?: any) => void
+  onNodeExpand?: (nodeId: string, expanded: boolean) => void
+  showLines?: boolean
+  showIcons?: boolean
+  selectable?: boolean
+  multiSelect?: boolean
+  animateExpand?: boolean
+  indent?: number
+}
+
+// Tree Provider
+const TreeProvider = React.forwardRef<HTMLDivElement, TreeProviderProps>(
+  (
+    {
+      className,
+      variant,
+      size,
+      children,
+      defaultExpandedIds = [],
+      selectedIds = [],
+      onSelectionChange,
+      onNodeClick,
+      onNodeExpand,
+      showLines = true,
+      showIcons = true,
+      selectable = true,
+      multiSelect = false,
+      animateExpand = true,
+      indent = 20,
+      ...props
+    },
+    ref,
+  ) => {
+    const [expandedIds, setExpandedIds] = React.useState<Set<string>>(new Set(defaultExpandedIds))
+    const [internalSelectedIds, setInternalSelectedIds] = React.useState<string[]>(selectedIds)
+
+    const isControlled = onSelectionChange !== undefined
+    const currentSelectedIds = isControlled ? selectedIds : internalSelectedIds
+
+    const toggleExpanded = React.useCallback(
+      (nodeId: string) => {
+        setExpandedIds((prev) => {
+          const newSet = new Set(prev)
+          const isExpanded = newSet.has(nodeId)
+          isExpanded ? newSet.delete(nodeId) : newSet.add(nodeId)
+          onNodeExpand?.(nodeId, !isExpanded)
+          return newSet
+        })
+      },
+      [onNodeExpand],
+    )
+
+    const handleSelection = React.useCallback(
+      (nodeId: string, ctrlKey = false) => {
+        if (!selectable) return
+
+        let newSelection: string[]
+
+        if (multiSelect && ctrlKey) {
+          newSelection = currentSelectedIds.includes(nodeId)
+            ? currentSelectedIds.filter((id) => id !== nodeId)
+            : [...currentSelectedIds, nodeId]
+        } else {
+          newSelection = currentSelectedIds.includes(nodeId) ? [] : [nodeId]
+        }
+
+        isControlled ? onSelectionChange?.(newSelection) : setInternalSelectedIds(newSelection)
+      },
+      [selectable, multiSelect, currentSelectedIds, isControlled, onSelectionChange],
+    )
+
+    const contextValue: TreeContextType = {
+      expandedIds,
+      selectedIds: currentSelectedIds,
+      toggleExpanded,
+      handleSelection,
+      showLines,
+      showIcons,
+      selectable,
+      multiSelect,
+      animateExpand,
+      indent,
+      onNodeClick,
+      onNodeExpand,
+    }
+
+    return (
+      <TreeContext.Provider value={contextValue}>
+        <motion.div
+          className={cn(treeVariants({ variant, size, className }))}
+          ref={ref}
+          initial={{ opacity: 0, y: 10 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.3, ease: "easeOut" }}
+        >
+          <div className="p-2" {...props}>
+            {children}
+          </div>
+        </motion.div>
+      </TreeContext.Provider>
+    )
+  },
+)
+
+TreeProvider.displayName = "TreeProvider"
+
+// Tree Props
+export interface TreeProps extends React.HTMLAttributes<HTMLDivElement> {
+  asChild?: boolean
+}
+
+// Tree
+const Tree = React.forwardRef<HTMLDivElement, TreeProps>(({ className, asChild = false, children, ...props }, ref) => {
+  const Comp = asChild ? Slot : "div"
+
+  return (
+    <Comp className={cn("space-y-1", className)} ref={ref} {...props}>
+      {children}
+    </Comp>
+  )
+})
+
+Tree.displayName = "Tree"
+
+// Tree Item Props
+export interface TreeItemProps extends React.HTMLAttributes<HTMLDivElement>, VariantProps<typeof treeItemVariants> {
+  nodeId: string
+  label: string
+  icon?: React.ReactNode
+  data?: any
+  level?: number
+  isLast?: boolean
+  parentPath?: boolean[]
+  hasChildren?: boolean
+  asChild?: boolean
+}
+
+// Tree Item
+const TreeItem = React.forwardRef<HTMLDivElement, TreeItemProps>(
+  (
+    {
+      className,
+      variant,
+      nodeId,
+      label,
+      icon,
+      data,
+      level = 0,
+      isLast = false,
+      parentPath = [],
+      hasChildren = false,
+      asChild = false,
+      children,
+      onClick,
+      ...props
+    },
+    ref,
+  ) => {
+    const {
+      expandedIds,
+      selectedIds,
+      toggleExpanded,
+      handleSelection,
+      showLines,
+      showIcons,
+      animateExpand,
+      indent,
+      onNodeClick,
+    } = useTree()
+
+    const isExpanded = expandedIds.has(nodeId)
+    const isSelected = selectedIds.includes(nodeId)
+    const currentPath = [...parentPath, isLast]
+
+    const getDefaultIcon = () =>
+      hasChildren ? (
+        isExpanded ? (
+          <FolderOpen className="h-4 w-4" />
+        ) : (
+          <Folder className="h-4 w-4" />
+        )
+      ) : (
+        <File className="h-4 w-4" />
+      )
+
+    const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
+      if (hasChildren) toggleExpanded(nodeId)
+      handleSelection(nodeId, e.ctrlKey || e.metaKey)
+      onNodeClick?.(nodeId, data)
+      onClick?.(e)
+    }
+
+    return (
+      <div className="select-none">
+        <motion.div
+          className={cn(treeItemVariants({ variant, selected: isSelected, className }))}
+          style={{ paddingLeft: level * indent + 8 }}
+          onClick={handleClick}
+          whileTap={{ scale: 0.98, transition: { duration: 0.1 } }}
+        >
+          {/* Tree Lines */}
+          {showLines && level > 0 && (
+            <div className="absolute left-0 top-0 bottom-0 pointer-events-none">
+              {currentPath.map((isLastInPath, pathIndex) => (
+                <div
+                  key={pathIndex}
+                  className="absolute top-0 bottom-0 border-l border-border/40"
+                  style={{
+                    left: pathIndex * indent + 12,
+                    display: pathIndex === currentPath.length - 1 && isLastInPath ? "none" : "block",
+                  }}
+                />
+              ))}
+              <div
+                className="absolute top-1/2 border-t border-border/40"
+                style={{
+                  left: (level - 1) * indent + 12,
+                  width: indent - 4,
+                  transform: "translateY(-1px)",
+                }}
+              />
+              {isLast && (
+                <div
+                  className="absolute top-0 border-l border-border/40"
+                  style={{
+                    left: (level - 1) * indent + 12,
+                    height: "50%",
+                  }}
+                />
+              )}
+            </div>
+          )}
+
+          {/* Expand Icon */}
+          <motion.div
+            className="flex items-center justify-center w-4 h-4 mr-1"
+            animate={{ rotate: hasChildren && isExpanded ? 90 : 0 }}
+            transition={{ duration: 0.2, ease: "easeInOut" }}
+          >
+            {hasChildren && <ChevronRight className="h-3 w-3 text-muted-foreground" />}
+          </motion.div>
+
+          {/* Node Icon */}
+          {showIcons && (
+            <motion.div
+              className="flex items-center justify-center w-4 h-4 mr-2 text-muted-foreground"
+              whileHover={{ scale: 1.1 }}
+              transition={{ duration: 0.15 }}
+            >
+              {icon || getDefaultIcon()}
+            </motion.div>
+          )}
+
+          {/* Label */}
+          <span className="text-sm truncate flex-1 text-foreground">{label}</span>
+        </motion.div>
+
+        {/* Children */}
+        <AnimatePresence>
+          {hasChildren && isExpanded && children && (
+            <motion.div
+              initial={{ height: 0, opacity: 0 }}
+              animate={{ height: "auto", opacity: 1 }}
+              exit={{ height: 0, opacity: 0 }}
+              transition={{
+                duration: animateExpand ? 0.3 : 0,
+                ease: "easeInOut",
+              }}
+              className="overflow-hidden"
+            >
+              <motion.div
+                initial={{ y: -10 }}
+                animate={{ y: 0 }}
+                exit={{ y: -10 }}
+                transition={{
+                  duration: animateExpand ? 0.2 : 0,
+                  delay: animateExpand ? 0.1 : 0,
+                }}
+              >
+                {children}
+              </motion.div>
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </div>
+    )
+  },
+)
+
+TreeItem.displayName = "TreeItem"
+
+export { TreeProvider, Tree, TreeItem, treeVariants, treeItemVariants }

--- a/components/ui/tree.tsx
+++ b/components/ui/tree.tsx
@@ -1,10 +1,10 @@
 "use client"
 
-import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
 import { cva, type VariantProps } from "class-variance-authority"
-import { ChevronRight, Folder, File, FolderOpen } from "lucide-react"
-import { motion, AnimatePresence } from "motion/react"
+import { ChevronRight, File, Folder, FolderOpen } from "lucide-react"
+import { AnimatePresence, motion } from "motion/react"
+import * as React from "react"
 import { cn } from "@/lib/utils"
 
 // Tree Context
@@ -195,7 +195,7 @@ const Tree = React.forwardRef<HTMLDivElement, TreeProps>(({ className, asChild =
   const Comp = asChild ? Slot : "div"
 
   return (
-    <Comp className={cn("space-y-1", className)} ref={ref} {...props}>
+    <Comp className={cn("space-y-1", className)} ref={ref} role={asChild ? undefined : "tree"} {...props}>
       {children}
     </Comp>
   )
@@ -204,7 +204,9 @@ const Tree = React.forwardRef<HTMLDivElement, TreeProps>(({ className, asChild =
 Tree.displayName = "Tree"
 
 // Tree Item Props
-export interface TreeItemProps extends React.HTMLAttributes<HTMLDivElement>, VariantProps<typeof treeItemVariants> {
+export interface TreeItemProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof treeItemVariants> {
   nodeId: string
   label: string
   icon?: React.ReactNode
@@ -213,11 +215,10 @@ export interface TreeItemProps extends React.HTMLAttributes<HTMLDivElement>, Var
   isLast?: boolean
   parentPath?: boolean[]
   hasChildren?: boolean
-  asChild?: boolean
 }
 
 // Tree Item
-const TreeItem = React.forwardRef<HTMLDivElement, TreeItemProps>(
+const TreeItem = React.forwardRef<HTMLButtonElement, TreeItemProps>(
   (
     {
       className,
@@ -230,10 +231,9 @@ const TreeItem = React.forwardRef<HTMLDivElement, TreeItemProps>(
       isLast = false,
       parentPath = [],
       hasChildren = false,
-      asChild = false,
       children,
       onClick,
-      ...props
+      ...buttonProps
     },
     ref,
   ) => {
@@ -264,20 +264,39 @@ const TreeItem = React.forwardRef<HTMLDivElement, TreeItemProps>(
         <File className="h-4 w-4" />
       )
 
-    const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
       if (hasChildren) toggleExpanded(nodeId)
       handleSelection(nodeId, e.ctrlKey || e.metaKey)
       onNodeClick?.(nodeId, data)
       onClick?.(e)
     }
 
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
+      if (!hasChildren) return
+
+      if (e.key === "ArrowRight" && !isExpanded) {
+        e.preventDefault()
+        toggleExpanded(nodeId)
+      }
+
+      if (e.key === "ArrowLeft" && isExpanded) {
+        e.preventDefault()
+        toggleExpanded(nodeId)
+      }
+    }
+
     return (
       <div className="select-none">
-        <motion.div
+        <button
+          ref={ref}
           className={cn(treeItemVariants({ variant, selected: isSelected, className }))}
           style={{ paddingLeft: level * indent + 8 }}
           onClick={handleClick}
-          whileTap={{ scale: 0.98, transition: { duration: 0.1 } }}
+          onKeyDown={handleKeyDown}
+          aria-expanded={hasChildren ? isExpanded : undefined}
+          aria-pressed={isSelected}
+          {...buttonProps}
+          type="button"
         >
           {/* Tree Lines */}
           {showLines && level > 0 && (
@@ -334,7 +353,7 @@ const TreeItem = React.forwardRef<HTMLDivElement, TreeItemProps>(
 
           {/* Label */}
           <span className="text-sm truncate flex-1 text-foreground">{label}</span>
-        </motion.div>
+        </button>
 
         {/* Children */}
         <AnimatePresence>

--- a/convex/documents.ts
+++ b/convex/documents.ts
@@ -1,5 +1,5 @@
 import { v } from "convex/values"
-import { api, internal } from "./_generated/api"
+import { internal } from "./_generated/api"
 import { action, internalMutation, internalQuery, mutation, query } from "./_generated/server"
 import { resolveProjectAccess, resolveProjectReader } from "./lib/access"
 

--- a/convex/documents.ts
+++ b/convex/documents.ts
@@ -246,7 +246,11 @@ export const remove = mutation({
 
     await resolveProjectAccess(
       ctx,
-      { projectId: doc.projectId, userId: args.userId, projectAccessToken: args.projectAccessToken },
+      {
+        projectId: doc.projectId,
+        userId: args.userId,
+        projectAccessToken: args.projectAccessToken,
+      },
       "editor",
     )
 
@@ -272,6 +276,38 @@ export const search = query({
   },
 })
 
+export const hasContentForProject = query({
+  args: {
+    projectId: v.id("projects"),
+    userId: v.optional(v.string()),
+    projectAccessToken: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const access = await resolveProjectReader(ctx, args)
+    if (!access) return true // fail closed — assume content exists if unauthorized
+
+    const firstDoc = await ctx.db
+      .query("documents")
+      .withIndex("by_projectId", (q) => q.eq("projectId", args.projectId))
+      .first()
+    if (firstDoc) return true
+
+    const firstFolder = await ctx.db
+      .query("folderMeta")
+      .withIndex("by_projectId", (q) => q.eq("projectId", args.projectId))
+      .first()
+    if (firstFolder) return true
+
+    const firstCollection = await ctx.db
+      .query("collections")
+      .withIndex("by_projectId", (q) => q.eq("projectId", args.projectId))
+      .first()
+    if (firstCollection) return true
+
+    return false
+  },
+})
+
 // Save draft - creates a history entry and updates the document
 export const saveDraft = mutation({
   args: {
@@ -289,7 +325,11 @@ export const saveDraft = mutation({
 
     const { userId } = await resolveProjectAccess(
       ctx,
-      { projectId: doc.projectId, userId: args.userId, projectAccessToken: args.projectAccessToken },
+      {
+        projectId: doc.projectId,
+        userId: args.userId,
+        projectAccessToken: args.projectAccessToken,
+      },
       "editor",
     )
 
@@ -349,7 +389,11 @@ export const publish = mutation({
 
     await resolveProjectAccess(
       ctx,
-      { projectId: doc.projectId, userId: args.editedBy, projectAccessToken: args.projectAccessToken },
+      {
+        projectId: doc.projectId,
+        userId: args.editedBy,
+        projectAccessToken: args.projectAccessToken,
+      },
       "editor",
     )
 
@@ -397,7 +441,11 @@ export const transitionStatus = mutation({
 
     await resolveProjectAccess(
       ctx,
-      { projectId: doc.projectId, userId: args.userId, projectAccessToken: args.projectAccessToken },
+      {
+        projectId: doc.projectId,
+        userId: args.userId,
+        projectAccessToken: args.projectAccessToken,
+      },
       "editor",
     )
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -81,15 +81,26 @@
       "devDependencies": {
         "@biomejs/biome": "2.4.1",
         "@tailwindcss/postcss": "^4.1.9",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
         "@types/node": "^22",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "jsdom": "^29.0.2",
         "postcss": "^8.5",
         "tailwindcss": "^4.1.9",
         "tw-animate-css": "1.3.3",
         "typescript": "^5",
         "vitest": "^4.0.18"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -102,6 +113,70 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.8",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.8.tgz",
+      "integrity": "sha512-OISPR9c2uPo23rUdvfEQiLPjoMLOpEeLNnP5iGkxr6tDDxJd3NjD+6fxY0mdaMbIPUjFGL4HFOJqLvow5q4aqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.1.1",
+        "@csstools/css-color-parser": "^4.0.2",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.0.8",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.0.8.tgz",
+      "integrity": "sha512-erMO6FgtM02dC24NGm0xufMzWz5OF0wXKR7BpvGD973bq/GbmR8/DbxNZbj0YevQ5hlToJaWSVK/G9/NDgGEVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -366,6 +441,19 @@
       ],
       "engines": {
         "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
       }
     },
     "node_modules/@codemirror/autocomplete": {
@@ -877,6 +965,146 @@
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+      "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
+      "integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.2.tgz",
+      "integrity": "sha512-5GkLzz4prTIpoyeUiIu3iV6CSG3Plo7xRVOFPKI7FVEJ3mZ0A8SwK0XU3Gl7xAkiQ+mDyam+NNp875/C5y+jSA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
     "node_modules/@date-fns/tz": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.2.0.tgz",
@@ -1360,6 +1588,24 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@floating-ui/core": {
@@ -6728,6 +6974,98 @@
         "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -7104,6 +7442,29 @@
       "integrity": "sha512-vcZjxvvVoxTeR5XBNJB38oTu/7eDCZlwdz32N1eNgpyPF7j/Z7Idf+CUwQOkKKpJ7RJyjxgLHCM7vdIK0iCNMQ==",
       "license": "MIT"
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -7123,6 +7484,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/asn1js": {
@@ -7386,6 +7757,16 @@
       "version": "1.1.21",
       "resolved": "https://registry.npmjs.org/@better-fetch/fetch/-/fetch-1.1.21.tgz",
       "integrity": "sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A=="
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
     },
     "node_modules/browserslist": {
       "version": "4.28.1",
@@ -7723,6 +8104,27 @@
         "uncrypto": "^0.1.3"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -7875,6 +8277,20 @@
         "node": ">=12"
       }
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/date-fns": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
@@ -7907,6 +8323,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decimal.js-light": {
       "version": "2.5.1",
@@ -7985,6 +8408,13 @@
       "engines": {
         "node": ">=0.3.1"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -8076,6 +8506,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-module-lexer": {
@@ -8650,6 +9093,19 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -8669,6 +9125,16 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/inline-style-parser": {
       "version": "0.2.7",
@@ -8805,6 +9271,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/jiti": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
@@ -8841,6 +9314,57 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.0.2",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.2.tgz",
+      "integrity": "sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.5",
+        "@asamuzakjp/dom-selector": "^7.0.6",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.1",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.24.5",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/undici": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.7.tgz",
+      "integrity": "sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/kind-of": {
@@ -9163,6 +9687,16 @@
       },
       "bin": {
         "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "11.3.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.2.tgz",
+      "integrity": "sha512-wgWa6FWQ3QRRJbIjbsldRJZxdxYngT/dO0I5Ynmlnin8qy7tC6xYzbcJjtN4wHLXtkbVwHzk0C+OejVw1XM+DQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/lucide-react": {
@@ -9548,6 +10082,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/micromark": {
       "version": "4.0.2",
@@ -10324,6 +10865,16 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/motion-dom": {
       "version": "12.36.0",
       "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.36.0.tgz",
@@ -10546,6 +11097,19 @@
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
       "license": "MIT"
     },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -10635,6 +11199,28 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/prismjs": {
       "version": "1.30.0",
       "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
@@ -10669,6 +11255,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/pvtsutils": {
@@ -10993,6 +11589,20 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/reflect-metadata": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
@@ -11103,6 +11713,16 @@
         "url": "https://github.com/sponsors/remeda"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/retry": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
@@ -11173,6 +11793,19 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -11369,6 +12002,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/style-mod": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
@@ -11415,6 +12061,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tabbable": {
       "version": "6.4.0",
@@ -11513,6 +12166,52 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
+      "integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.28"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
+      "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/trim-lines": {
@@ -12090,6 +12789,54 @@
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
       "license": "MIT"
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -12106,6 +12853,23 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/zod": {
       "version": "3.25.76",

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,6 +63,7 @@
         "input-otp": "1.4.1",
         "lucide-react": "^0.454.0",
         "magic-string": "^0.30.21",
+        "motion": "^12.38.0",
         "next": "16.0.10",
         "next-themes": "^0.4.6",
         "react": "19.2.0",
@@ -8930,12 +8931,12 @@
       }
     },
     "node_modules/framer-motion": {
-      "version": "12.36.0",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.36.0.tgz",
-      "integrity": "sha512-4PqYHAT7gev0ke0wos+PyrcFxI0HScjm3asgU8nSYa8YzJFuwgIvdj3/s3ZaxLq0bUSboIn19A2WS/MHwLCvfw==",
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.38.0.tgz",
+      "integrity": "sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==",
       "license": "MIT",
       "dependencies": {
-        "motion-dom": "^12.36.0",
+        "motion-dom": "^12.38.0",
         "motion-utils": "^12.36.0",
         "tslib": "^2.4.0"
       },
@@ -10875,10 +10876,36 @@
         "node": ">=4"
       }
     },
+    "node_modules/motion": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/motion/-/motion-12.38.0.tgz",
+      "integrity": "sha512-uYfXzeHlgThchzwz5Te47dlv5JOUC7OB4rjJ/7XTUgtBZD8CchMN8qEJ4ZVsUmTyYA44zjV0fBwsiktRuFnn+w==",
+      "license": "MIT",
+      "dependencies": {
+        "framer-motion": "^12.38.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/motion-dom": {
-      "version": "12.36.0",
-      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.36.0.tgz",
-      "integrity": "sha512-Ep1pq8P88rGJ75om8lTCA13zqd7ywPGwCqwuWwin6BKc0hMLkVfcS6qKlRqEo2+t0DwoUcgGJfXwaiFn4AOcQA==",
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.38.0.tgz",
+      "integrity": "sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==",
       "license": "MIT",
       "dependencies": {
         "motion-utils": "^12.36.0"

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "input-otp": "1.4.1",
     "lucide-react": "^0.454.0",
     "magic-string": "^0.30.21",
+    "motion": "^12.38.0",
     "next": "16.0.10",
     "next-themes": "^0.4.6",
     "react": "19.2.0",

--- a/package.json
+++ b/package.json
@@ -86,9 +86,13 @@
   "devDependencies": {
     "@biomejs/biome": "2.4.1",
     "@tailwindcss/postcss": "^4.1.9",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
     "@types/node": "^22",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "jsdom": "^29.0.2",
     "postcss": "^8.5",
     "tailwindcss": "^4.1.9",
     "tw-animate-css": "1.3.3",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,8 +5,6 @@ export default defineConfig({
   test: {
     include: ["**/__tests__/**/*.test.ts", "**/__tests__/**/*.test.tsx"],
     exclude: ["node_modules", ".next", "convex"],
-    environment: "jsdom",
-    setupFiles: ["./vitest.setup.ts"],
   },
   resolve: {
     alias: {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,8 @@ export default defineConfig({
   test: {
     include: ["**/__tests__/**/*.test.ts", "**/__tests__/**/*.test.tsx"],
     exclude: ["node_modules", ".next", "convex"],
+    environment: "jsdom",
+    setupFiles: ["./vitest.setup.ts"],
   },
   resolve: {
     alias: {

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,1 +1,0 @@
-import "@testing-library/jest-dom/vitest"

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom/vitest"


### PR DESCRIPTION
## Summary

### Folder Picker for Content Root Selection
- Add a visual folder picker dialog that lets users browse GitHub repositories instead of typing folder paths manually
- Integrate picker into RepoSetupForm (project setup wizard) and AddProjectDialog (add new project)
- Add safety gate that prevents changing content root when a project has existing documents (prevents data loss)
- Add unit tests for the FolderPickerDialog component

### Studio Redirect & Performance Fix
- Fix navigation from dashboard to studio failing for org repo collaborators (redirect bug caused by `actingUserId` gate blocking the content-read probe)
- Remove synchronous `getContentTree` from server component; large repos (e.g. 4+ min load) now load in milliseconds
- Defer file tree loading to client via new `GET /api/github/tree` route
- Parallelise auth, project lookup, and role resolution with `Promise.all` (Batch 1 + Batch 2)
- Use `resolveRepoRole` instead of hand-rolled inline fallback chain
- Fix tab restore regression: guard `use-studio-file` restore effect against empty tree to prevent wiping localStorage

## Changes

| File | Change |
|------|--------|
| `app/dashboard/[owner]/[repo]/actions.ts` | Add `fetchRepoDirsAction` server action |
| `components/folder-picker-dialog.tsx` | **NEW** — Reusable folder picker with lazy-loading tree |
| `components/repo-setup-form.tsx` | Replace text input with folder picker |
| `components/add-project-dialog.tsx` | Replace text input with folder picker |
| `convex/documents.ts` | Add `hasContentForProject` query for safety gate |
| `components/edit-project-dialog.tsx` | Conditional picker (if no content) or locked input |
| `app/dashboard/[owner]/[repo]/config-actions.ts` | Allow contentRoot updates with directory validation |
| `components/__tests__/folder-picker-dialog.test.tsx` | **NEW** — 7 unit tests |
| `app/dashboard/[owner]/[repo]/studio/[[...path]]/page.tsx` | Rewrite: parallel batches, `resolveRepoRole`, remove `getContentTree` |
| `app/api/github/tree/route.ts` | **NEW** — Client-side tree fetch endpoint |
| `components/studio/studio-layout.tsx` | Add client-side tree loading in `StudioProviderWrapper` |
| `components/studio/hooks/use-studio-file.ts` | Guard restore effect against empty tree |

## Test Plan

- [x] All 7 folder picker tests pass
- [x] Full test suite passes (448 tests)
- [x] Manual: folder picker opens, directories load, selection works
- [x] Manual: studio page loads without redirect for org repo collaborators
- [x] Manual: studio page loads quickly for large repos (file tree loads async)