### PR TITLE
Improve publish PR naming and copy UX (PR from RepoPress)

### DIFF
--- a/app/api/github/publish-ops/__tests__/route.test.ts
+++ b/app/api/github/publish-ops/__tests__/route.test.ts
@@ -304,14 +304,14 @@ describe("POST /api/github/publish-ops", () => {
       "acme",
       "docs-site",
       "main",
-      "repopress/publish/main/1700000000000",
+      "repopress/publish/main/2023-11-14-221320-loyw3v28",
     )
     expect(createPullRequest).toHaveBeenCalledTimes(1)
     expect(createPullRequest).toHaveBeenCalledWith(
       "gh-token",
       "acme",
       "docs-site",
-      "repopress/publish/main/1700000000000",
+      "repopress/publish/main/2023-11-14-221320-loyw3v28",
       "main",
       "Content update via RepoPress (1 updated) (PR from RepoPress)",
       "Automated content update from RepoPress.\n\n- 1 updated",
@@ -321,13 +321,13 @@ describe("POST /api/github/publish-ops", () => {
         typeof args === "object" &&
         args !== null &&
         "branchName" in args &&
-        args.branchName === "repopress/publish/main/1700000000000",
+        args.branchName === "repopress/publish/main/2023-11-14-221320-loyw3v28",
     )
     expect(createPublishBranchCall?.[1]).toEqual(
       expect.objectContaining({
         projectId: "project_123",
         userId: "user_owner",
-        branchName: "repopress/publish/main/1700000000000",
+        branchName: "repopress/publish/main/2023-11-14-221320-loyw3v28",
         baseBranch: "main",
       }),
     )
@@ -363,7 +363,7 @@ describe("POST /api/github/publish-ops", () => {
       ],
       refreshedPublishBranch: {
         _id: "publish_branch_2",
-        branchName: "repopress/publish/main/1700000000002",
+        branchName: "repopress/publish/main/2023-11-14-221320-loyw3v2a",
         prNumber: undefined,
         prUrl: undefined,
         committedFilePaths: [],
@@ -385,13 +385,13 @@ describe("POST /api/github/publish-ops", () => {
       "acme",
       "docs-site",
       "main",
-      "repopress/publish/main/1700000000002",
+      "repopress/publish/main/2023-11-14-221320-loyw3v2a",
     )
     expect(createPullRequest).toHaveBeenCalledWith(
       "gh-token",
       "acme",
       "docs-site",
-      "repopress/publish/main/1700000000002",
+      "repopress/publish/main/2023-11-14-221320-loyw3v2a",
       "main",
       "Content update via RepoPress (1 updated) (PR from RepoPress)",
       "Automated content update from RepoPress.\n\n- 1 updated",
@@ -567,7 +567,7 @@ describe("POST /api/github/publish-ops", () => {
       "acme",
       "docs-site",
       "main",
-      "repopress/publish/main/1700000000001",
+      "repopress/publish/main/2023-11-14-221320-loyw3v29",
     )
     expect(createPullRequest).toHaveBeenCalledTimes(1)
     expect(batchCommit).toHaveBeenCalledTimes(1)
@@ -615,13 +615,13 @@ describe("POST /api/github/publish-ops", () => {
       "acme",
       "docs-site",
       "main",
-      "repopress/publish/main/1700000000002",
+      "repopress/publish/main/2023-11-14-221320-loyw3v2a",
     )
     expect(createGitHubClient).toHaveBeenCalledWith("gh-token")
     expect(deleteRefMock).toHaveBeenCalledWith({
       owner: "acme",
       repo: "docs-site",
-      ref: "heads/repopress/publish/main/1700000000002",
+      ref: "heads/repopress/publish/main/2023-11-14-221320-loyw3v2a",
     })
     expect(
       convexMutationMock.mock.calls.some(
@@ -678,7 +678,7 @@ describe("POST /api/github/publish-ops", () => {
     expect(deleteRefMock).toHaveBeenCalledWith({
       owner: "acme",
       repo: "docs-site",
-      ref: "heads/repopress/publish/main/1700000000003",
+      ref: "heads/repopress/publish/main/2023-11-14-221320-loyw3v2b",
     })
     expect(consoleErrorSpy).toHaveBeenCalledWith(
       "Failed to clean up orphaned publish branch after conflict:",

--- a/app/api/github/publish-ops/__tests__/route.test.ts
+++ b/app/api/github/publish-ops/__tests__/route.test.ts
@@ -28,6 +28,7 @@ vi.mock("@/lib/github", () => ({
   createGitHubClient: vi.fn(),
   createPullRequest: vi.fn(),
   getFile: vi.fn(),
+  updatePullRequest: vi.fn(),
 }))
 
 vi.mock("@/lib/github-permissions", () => ({
@@ -42,7 +43,14 @@ vi.mock("@/lib/github-permissions", () => ({
 process.env.NEXT_PUBLIC_CONVEX_URL = process.env.NEXT_PUBLIC_CONVEX_URL || "https://example.convex.cloud"
 
 import { fetchAuthQuery, getGitHubToken, getPatAuthUserId } from "@/lib/auth-server"
-import { batchCommit, createBranch, createGitHubClient, createPullRequest, getFile } from "@/lib/github"
+import {
+  batchCommit,
+  createBranch,
+  createGitHubClient,
+  createPullRequest,
+  getFile,
+  updatePullRequest,
+} from "@/lib/github"
 import { getRepoRole } from "@/lib/github-permissions"
 import { POST } from "../route"
 
@@ -137,6 +145,7 @@ describe("POST /api/github/publish-ops", () => {
       number: 99,
       htmlUrl: "https://github.com/acme/docs-site/pull/99",
     } as never)
+    vi.mocked(updatePullRequest).mockResolvedValue(undefined as never)
 
     mockPublishQueries({})
   })
@@ -290,15 +299,21 @@ describe("POST /api/github/publish-ops", () => {
     expect(payload.ok).toBe(true)
     expect(payload.publishModeUsed).toBe("create-new")
     expect(createBranch).toHaveBeenCalledTimes(1)
-    expect(createBranch).toHaveBeenCalledWith("gh-token", "acme", "docs-site", "main", "repopress/main/1700000000000")
+    expect(createBranch).toHaveBeenCalledWith(
+      "gh-token",
+      "acme",
+      "docs-site",
+      "main",
+      "repopress/publish/main/1700000000000",
+    )
     expect(createPullRequest).toHaveBeenCalledTimes(1)
     expect(createPullRequest).toHaveBeenCalledWith(
       "gh-token",
       "acme",
       "docs-site",
-      "repopress/main/1700000000000",
+      "repopress/publish/main/1700000000000",
       "main",
-      "Content update via RepoPress (1 updated)",
+      "Content update via RepoPress (1 updated) (PR from RepoPress)",
       "Automated content update from RepoPress.\n\n- 1 updated",
     )
     const createPublishBranchCall = convexMutationMock.mock.calls.find(
@@ -306,16 +321,131 @@ describe("POST /api/github/publish-ops", () => {
         typeof args === "object" &&
         args !== null &&
         "branchName" in args &&
-        args.branchName === "repopress/main/1700000000000",
+        args.branchName === "repopress/publish/main/1700000000000",
     )
     expect(createPublishBranchCall?.[1]).toEqual(
       expect.objectContaining({
         projectId: "project_123",
         userId: "user_owner",
-        branchName: "repopress/main/1700000000000",
+        branchName: "repopress/publish/main/1700000000000",
         baseBranch: "main",
       }),
     )
+  })
+
+  it("brands the default PR title and publish branch name for create-new", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_002)
+    mockPublishQueries({
+      pendingOps: [],
+      dirtyDocs: [
+        {
+          _id: "doc_1",
+          filePath: "posts/hello.mdx",
+          body: "# Hello",
+          frontmatter: { title: "Hello" },
+        },
+      ],
+      pendingMediaOps: [],
+      currentPublishBranch: {
+        _id: "publish_branch_1",
+        branchName: "repopress/main/1234",
+        prNumber: 42,
+        prUrl: "https://github.com/acme/docs-site/pull/42",
+        committedFilePaths: ["content/posts/hello.mdx"],
+      },
+      openPublishBranches: [
+        {
+          _id: "publish_branch_1",
+          branchName: "repopress/main/1234",
+          prNumber: 42,
+          committedFilePaths: ["content/posts/hello.mdx"],
+        },
+      ],
+      refreshedPublishBranch: {
+        _id: "publish_branch_2",
+        branchName: "repopress/publish/main/1700000000002",
+        prNumber: undefined,
+        prUrl: undefined,
+        committedFilePaths: [],
+      },
+    })
+
+    const response = await POST(
+      buildRequest({
+        projectId: "project_123",
+        publishMode: "create-new",
+      }),
+    )
+    const payload = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(payload.ok).toBe(true)
+    expect(createBranch).toHaveBeenCalledWith(
+      "gh-token",
+      "acme",
+      "docs-site",
+      "main",
+      "repopress/publish/main/1700000000002",
+    )
+    expect(createPullRequest).toHaveBeenCalledWith(
+      "gh-token",
+      "acme",
+      "docs-site",
+      "repopress/publish/main/1700000000002",
+      "main",
+      "Content update via RepoPress (1 updated) (PR from RepoPress)",
+      "Automated content update from RepoPress.\n\n- 1 updated",
+    )
+  })
+
+  it("updates the existing PR title and description when reuse-current receives custom copy", async () => {
+    const response = await POST(
+      buildRequest({
+        projectId: "project_123",
+        publishMode: "reuse-current",
+        title: "docs: tighten publish UX (PR from RepoPress)",
+        description: "Refresh the copy and branch naming for publish flows.",
+      }),
+    )
+    const payload = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(payload.ok).toBe(true)
+    expect(createPullRequest).not.toHaveBeenCalled()
+    expect(updatePullRequest).toHaveBeenCalledWith("gh-token", "acme", "docs-site", 42, {
+      title: "docs: tighten publish UX (PR from RepoPress)",
+      body: "Refresh the copy and branch naming for publish flows.",
+    })
+  })
+
+  it("keeps the publish successful when the existing PR metadata update fails", async () => {
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+    vi.mocked(updatePullRequest).mockRejectedValueOnce(new Error("GitHub PR update failed"))
+
+    const response = await POST(
+      buildRequest({
+        projectId: "project_123",
+        publishMode: "reuse-current",
+        title: "docs: tighten publish UX (PR from RepoPress)",
+        description: "Refresh the copy and branch naming for publish flows.",
+      }),
+    )
+    const payload = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(payload.ok).toBe(true)
+    expect(payload.warning).toBe("Commit pushed, but updating the existing PR title/description failed.")
+    expect(batchCommit).toHaveBeenCalledTimes(1)
+    expect(convexMutationMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        id: "publish_branch_1",
+        prNumber: 42,
+        prUrl: "https://github.com/acme/docs-site/pull/42",
+        lastCommitSha: "commit-sha-1",
+      }),
+    )
+    expect(consoleErrorSpy).toHaveBeenCalledWith("Failed to update existing PR metadata:", expect.any(Error))
   })
 
   it("returns 409 when create-new overlaps files tracked by another open PR", async () => {
@@ -432,7 +562,13 @@ describe("POST /api/github/publish-ops", () => {
     expect(response.status).toBe(200)
     expect(payload.ok).toBe(true)
     expect(payload.publishModeUsed).toBe("create-new")
-    expect(createBranch).toHaveBeenCalledWith("gh-token", "acme", "docs-site", "main", "repopress/main/1700000000001")
+    expect(createBranch).toHaveBeenCalledWith(
+      "gh-token",
+      "acme",
+      "docs-site",
+      "main",
+      "repopress/publish/main/1700000000001",
+    )
     expect(createPullRequest).toHaveBeenCalledTimes(1)
     expect(batchCommit).toHaveBeenCalledTimes(1)
   })
@@ -474,12 +610,18 @@ describe("POST /api/github/publish-ops", () => {
     expect(response.status).toBe(409)
     expect(payload.ok).toBe(false)
     expect(payload.error).toContain("active publish lane")
-    expect(createBranch).toHaveBeenCalledWith("gh-token", "acme", "docs-site", "main", "repopress/main/1700000000002")
+    expect(createBranch).toHaveBeenCalledWith(
+      "gh-token",
+      "acme",
+      "docs-site",
+      "main",
+      "repopress/publish/main/1700000000002",
+    )
     expect(createGitHubClient).toHaveBeenCalledWith("gh-token")
     expect(deleteRefMock).toHaveBeenCalledWith({
       owner: "acme",
       repo: "docs-site",
-      ref: "heads/repopress/main/1700000000002",
+      ref: "heads/repopress/publish/main/1700000000002",
     })
     expect(
       convexMutationMock.mock.calls.some(
@@ -536,7 +678,7 @@ describe("POST /api/github/publish-ops", () => {
     expect(deleteRefMock).toHaveBeenCalledWith({
       owner: "acme",
       repo: "docs-site",
-      ref: "heads/repopress/main/1700000000003",
+      ref: "heads/repopress/publish/main/1700000000003",
     })
     expect(consoleErrorSpy).toHaveBeenCalledWith(
       "Failed to clean up orphaned publish branch after conflict:",

--- a/app/api/github/publish-ops/__tests__/route.test.ts
+++ b/app/api/github/publish-ops/__tests__/route.test.ts
@@ -24,6 +24,7 @@ vi.mock("@/lib/auth-server", () => ({
 
 vi.mock("@/lib/github", () => ({
   batchCommit: vi.fn(),
+  branchExists: vi.fn(),
   createBranch: vi.fn(),
   createGitHubClient: vi.fn(),
   createPullRequest: vi.fn(),
@@ -45,6 +46,7 @@ process.env.NEXT_PUBLIC_CONVEX_URL = process.env.NEXT_PUBLIC_CONVEX_URL || "http
 import { fetchAuthQuery, getGitHubToken, getPatAuthUserId } from "@/lib/auth-server"
 import {
   batchCommit,
+  branchExists,
   createBranch,
   createGitHubClient,
   createPullRequest,
@@ -81,6 +83,7 @@ function mockPublishQueries({
     prUrl: "https://github.com/acme/docs-site/pull/42",
   },
   openPublishBranches,
+  existingBranchNames = [],
   refreshedPublishBranch,
 }: {
   pendingOps?: Array<Record<string, unknown>>
@@ -88,6 +91,7 @@ function mockPublishQueries({
   pendingMediaOps?: Array<Record<string, unknown>>
   currentPublishBranch?: Record<string, unknown> | null
   openPublishBranches?: Array<Record<string, unknown>>
+  existingBranchNames?: string[]
   refreshedPublishBranch?: Record<string, unknown>
 }) {
   convexQueryMock.mockReset()
@@ -101,6 +105,8 @@ function mockPublishQueries({
   if (openPublishBranches !== undefined) {
     convexQueryMock.mockResolvedValueOnce(openPublishBranches)
   }
+
+  convexQueryMock.mockResolvedValueOnce(existingBranchNames)
 
   if (refreshedPublishBranch !== undefined) {
     convexQueryMock.mockResolvedValueOnce(refreshedPublishBranch)
@@ -140,6 +146,7 @@ describe("POST /api/github/publish-ops", () => {
     } as never)
     vi.mocked(batchCommit).mockResolvedValue({ commitSha: "commit-sha-1" } as never)
     vi.mocked(getFile).mockResolvedValue({ sha: "new-sha-1" } as never)
+    vi.mocked(branchExists).mockResolvedValue(false)
     vi.mocked(createBranch).mockResolvedValue(undefined as never)
     vi.mocked(createPullRequest).mockResolvedValue({
       number: 99,
@@ -251,7 +258,6 @@ describe("POST /api/github/publish-ops", () => {
   })
 
   it("creates a new PR when publishMode is create-new", async () => {
-    vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_000)
     mockPublishQueries({
       pendingOps: [],
       dirtyDocs: [
@@ -278,9 +284,10 @@ describe("POST /api/github/publish-ops", () => {
           committedFilePaths: ["content/posts/hello.mdx"],
         },
       ],
+      existingBranchNames: ["repopress/main/1234"],
       refreshedPublishBranch: {
         _id: "publish_branch_2",
-        branchName: "repopress/main/5678",
+        branchName: "repopress/hello",
         prNumber: undefined,
         prUrl: undefined,
         committedFilePaths: [],
@@ -299,42 +306,100 @@ describe("POST /api/github/publish-ops", () => {
     expect(payload.ok).toBe(true)
     expect(payload.publishModeUsed).toBe("create-new")
     expect(createBranch).toHaveBeenCalledTimes(1)
-    expect(createBranch).toHaveBeenCalledWith(
-      "gh-token",
-      "acme",
-      "docs-site",
-      "main",
-      "repopress/publish/main/2023-11-14-221320-loyw3v28",
-    )
+    expect(createBranch).toHaveBeenCalledWith("gh-token", "acme", "docs-site", "main", "repopress/hello")
     expect(createPullRequest).toHaveBeenCalledTimes(1)
     expect(createPullRequest).toHaveBeenCalledWith(
       "gh-token",
       "acme",
       "docs-site",
-      "repopress/publish/main/2023-11-14-221320-loyw3v28",
+      "repopress/hello",
       "main",
       "Content update via RepoPress (1 updated) (PR from RepoPress)",
       "Automated content update from RepoPress.\n\n- 1 updated",
     )
     const createPublishBranchCall = convexMutationMock.mock.calls.find(
       ([, args]) =>
-        typeof args === "object" &&
-        args !== null &&
-        "branchName" in args &&
-        args.branchName === "repopress/publish/main/2023-11-14-221320-loyw3v28",
+        typeof args === "object" && args !== null && "branchName" in args && args.branchName === "repopress/hello",
     )
     expect(createPublishBranchCall?.[1]).toEqual(
       expect.objectContaining({
         projectId: "project_123",
         userId: "user_owner",
-        branchName: "repopress/publish/main/2023-11-14-221320-loyw3v28",
+        branchName: "repopress/hello",
         baseBranch: "main",
       }),
     )
   })
 
-  it("brands the default PR title and publish branch name for create-new", async () => {
-    vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_002)
+  it("uses a multi-change branch scope when create-new spans multiple areas", async () => {
+    vi.mocked(getFile).mockResolvedValue(null as never)
+    mockPublishQueries({
+      pendingOps: [
+        {
+          _id: "explorer_op_1",
+          opType: "create",
+          filePath: "guides/getting-started.mdx",
+          initialBody: "# Getting started",
+          initialFrontmatter: { title: "Getting started" },
+        },
+      ],
+      dirtyDocs: [
+        {
+          _id: "doc_1",
+          filePath: "posts/hello.mdx",
+          body: "# Hello",
+          frontmatter: { title: "Hello" },
+        },
+      ],
+      pendingMediaOps: [],
+      currentPublishBranch: {
+        _id: "publish_branch_1",
+        branchName: "repopress/main/1234",
+        prNumber: 42,
+        prUrl: "https://github.com/acme/docs-site/pull/42",
+        committedFilePaths: ["content/posts/hello.mdx"],
+      },
+      openPublishBranches: [
+        {
+          _id: "publish_branch_1",
+          branchName: "repopress/main/1234",
+          prNumber: 42,
+          committedFilePaths: ["content/posts/hello.mdx"],
+        },
+      ],
+      existingBranchNames: ["repopress/main/1234"],
+      refreshedPublishBranch: {
+        _id: "publish_branch_2",
+        branchName: "repopress/multi-change",
+        prNumber: undefined,
+        prUrl: undefined,
+        committedFilePaths: [],
+      },
+    })
+
+    const response = await POST(
+      buildRequest({
+        projectId: "project_123",
+        publishMode: "create-new",
+      }),
+    )
+    const payload = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(payload.ok).toBe(true)
+    expect(createBranch).toHaveBeenCalledWith("gh-token", "acme", "docs-site", "main", "repopress/multi-change")
+    expect(createPullRequest).toHaveBeenCalledWith(
+      "gh-token",
+      "acme",
+      "docs-site",
+      "repopress/multi-change",
+      "main",
+      "Content update via RepoPress (1 created, 1 updated) (PR from RepoPress)",
+      "Automated content update from RepoPress.\n\n- 1 created\n- 1 updated",
+    )
+  })
+
+  it("adds an ordinal suffix when the preferred scope branch name is already taken", async () => {
     mockPublishQueries({
       pendingOps: [],
       dirtyDocs: [
@@ -361,9 +426,10 @@ describe("POST /api/github/publish-ops", () => {
           committedFilePaths: ["content/posts/hello.mdx"],
         },
       ],
+      existingBranchNames: ["repopress/main/1234", "repopress/hello", "repopress/hello-2"],
       refreshedPublishBranch: {
         _id: "publish_branch_2",
-        branchName: "repopress/publish/main/2023-11-14-221320-loyw3v2a",
+        branchName: "repopress/hello-3",
         prNumber: undefined,
         prUrl: undefined,
         committedFilePaths: [],
@@ -380,18 +446,12 @@ describe("POST /api/github/publish-ops", () => {
 
     expect(response.status).toBe(200)
     expect(payload.ok).toBe(true)
-    expect(createBranch).toHaveBeenCalledWith(
-      "gh-token",
-      "acme",
-      "docs-site",
-      "main",
-      "repopress/publish/main/2023-11-14-221320-loyw3v2a",
-    )
+    expect(createBranch).toHaveBeenCalledWith("gh-token", "acme", "docs-site", "main", "repopress/hello-3")
     expect(createPullRequest).toHaveBeenCalledWith(
       "gh-token",
       "acme",
       "docs-site",
-      "repopress/publish/main/2023-11-14-221320-loyw3v2a",
+      "repopress/hello-3",
       "main",
       "Content update via RepoPress (1 updated) (PR from RepoPress)",
       "Automated content update from RepoPress.\n\n- 1 updated",
@@ -502,7 +562,6 @@ describe("POST /api/github/publish-ops", () => {
   })
 
   it("ignores inactive overlapping publish branches when create-new is requested", async () => {
-    vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_001)
     vi.mocked(getFile).mockResolvedValue(null as never)
     mockPublishQueries({
       pendingOps: [
@@ -541,9 +600,10 @@ describe("POST /api/github/publish-ops", () => {
           committedFilePaths: ["content/posts/new-lane.mdx"],
         },
       ],
+      existingBranchNames: ["repopress/main/1234", "repopress/main/8888"],
       refreshedPublishBranch: {
         _id: "publish_branch_2",
-        branchName: "repopress/main/5678",
+        branchName: "repopress/new-lane",
         prNumber: undefined,
         prUrl: undefined,
         status: "active",
@@ -562,19 +622,12 @@ describe("POST /api/github/publish-ops", () => {
     expect(response.status).toBe(200)
     expect(payload.ok).toBe(true)
     expect(payload.publishModeUsed).toBe("create-new")
-    expect(createBranch).toHaveBeenCalledWith(
-      "gh-token",
-      "acme",
-      "docs-site",
-      "main",
-      "repopress/publish/main/2023-11-14-221320-loyw3v29",
-    )
+    expect(createBranch).toHaveBeenCalledWith("gh-token", "acme", "docs-site", "main", "repopress/new-lane")
     expect(createPullRequest).toHaveBeenCalledTimes(1)
     expect(batchCommit).toHaveBeenCalledTimes(1)
   })
 
   it("returns 409 when create-new loses the race to create the next active lane", async () => {
-    vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_002)
     mockPublishQueries({
       currentPublishBranch: {
         _id: "publish_branch_1",
@@ -591,6 +644,7 @@ describe("POST /api/github/publish-ops", () => {
           committedFilePaths: [],
         },
       ],
+      existingBranchNames: ["repopress/main/1234"],
     })
     convexMutationMock.mockImplementation(async (_ref, args) => {
       if (typeof args === "object" && args !== null && "branchName" in args) {
@@ -610,18 +664,12 @@ describe("POST /api/github/publish-ops", () => {
     expect(response.status).toBe(409)
     expect(payload.ok).toBe(false)
     expect(payload.error).toContain("active publish lane")
-    expect(createBranch).toHaveBeenCalledWith(
-      "gh-token",
-      "acme",
-      "docs-site",
-      "main",
-      "repopress/publish/main/2023-11-14-221320-loyw3v2a",
-    )
+    expect(createBranch).toHaveBeenCalledWith("gh-token", "acme", "docs-site", "main", "repopress/hello")
     expect(createGitHubClient).toHaveBeenCalledWith("gh-token")
     expect(deleteRefMock).toHaveBeenCalledWith({
       owner: "acme",
       repo: "docs-site",
-      ref: "heads/repopress/publish/main/2023-11-14-221320-loyw3v2a",
+      ref: "heads/repopress/hello",
     })
     expect(
       convexMutationMock.mock.calls.some(
@@ -638,7 +686,6 @@ describe("POST /api/github/publish-ops", () => {
   })
 
   it("still returns 409 when orphaned branch cleanup fails after the active-lane race", async () => {
-    vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_003)
     const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
     deleteRefMock.mockRejectedValueOnce(new Error("cleanup failed"))
     mockPublishQueries({
@@ -657,6 +704,7 @@ describe("POST /api/github/publish-ops", () => {
           committedFilePaths: [],
         },
       ],
+      existingBranchNames: ["repopress/main/1234"],
     })
     convexMutationMock.mockImplementation(async (_ref, args) => {
       if (typeof args === "object" && args !== null && "branchName" in args) {
@@ -678,7 +726,7 @@ describe("POST /api/github/publish-ops", () => {
     expect(deleteRefMock).toHaveBeenCalledWith({
       owner: "acme",
       repo: "docs-site",
-      ref: "heads/repopress/publish/main/2023-11-14-221320-loyw3v2b",
+      ref: "heads/repopress/hello",
     })
     expect(consoleErrorSpy).toHaveBeenCalledWith(
       "Failed to clean up orphaned publish branch after conflict:",

--- a/app/api/github/publish-ops/route.ts
+++ b/app/api/github/publish-ops/route.ts
@@ -14,6 +14,7 @@ import {
   updatePullRequest,
 } from "@/lib/github"
 import { mintServerQueryToken } from "@/lib/project-access-token"
+import { buildPublishBranchName } from "@/lib/publish-branch-name"
 import { RouteAuthError, resolveRouteAuth } from "@/lib/route-auth"
 import { isStudioMediaResolveUrl } from "@/lib/studio/media-resolve"
 
@@ -245,9 +246,7 @@ export async function POST(request: Request) {
       publishBranch = null
     }
 
-    // If no active branch exists, create a new publish branch with timestamp-based name.
-    // Branch naming: repopress/publish/${baseBranch}/${timestamp}
-    const branchName = publishBranch?.branchName || `repopress/publish/${baseBranch}/${Date.now()}`
+    const branchName = publishBranch?.branchName || buildPublishBranchName(baseBranch)
 
     if (!publishBranch) {
       await createBranch(token, owner, repo, baseBranch, branchName)

--- a/app/api/github/publish-ops/route.ts
+++ b/app/api/github/publish-ops/route.ts
@@ -7,6 +7,7 @@ import { prefixContentRoot } from "@/lib/explorer-tree-overlay"
 import type { BatchOperation } from "@/lib/github"
 import {
   batchCommit,
+  branchExists,
   createBranch,
   createGitHubClient,
   createPullRequest,
@@ -14,7 +15,7 @@ import {
   updatePullRequest,
 } from "@/lib/github"
 import { mintServerQueryToken } from "@/lib/project-access-token"
-import { buildPublishBranchName } from "@/lib/publish-branch-name"
+import { buildPublishBranchName, derivePublishBranchScope } from "@/lib/publish-branch-name"
 import { RouteAuthError, resolveRouteAuth } from "@/lib/route-auth"
 import { isStudioMediaResolveUrl } from "@/lib/studio/media-resolve"
 
@@ -246,10 +247,25 @@ export async function POST(request: Request) {
       publishBranch = null
     }
 
-    const branchName = publishBranch?.branchName || buildPublishBranchName(baseBranch)
+    let branchName = publishBranch?.branchName
 
     if (!publishBranch) {
-      await createBranch(token, owner, repo, baseBranch, branchName)
+      const existingBranchNames = await convex.query(api.publishBranches.listBranchNamesForProject, {
+        projectId: project._id,
+        ...queryAuth,
+      })
+      const scope = derivePublishBranchScope(
+        operations.map((operation) => operation.path),
+        contentRoot,
+      )
+      branchName = await createAvailablePublishBranch({
+        token,
+        owner,
+        repo,
+        baseBranch,
+        scope,
+        existingBranchNames,
+      })
       try {
         await convex.mutation(api.publishBranches.create, {
           projectId: project._id,
@@ -404,6 +420,53 @@ export async function POST(request: Request) {
 
 function isActivePublishBranchConflict(error: unknown) {
   return error instanceof Error && error.message.includes(ACTIVE_PUBLISH_BRANCH_CONFLICT_MESSAGE)
+}
+
+async function createAvailablePublishBranch({
+  token,
+  owner,
+  repo,
+  baseBranch,
+  scope,
+  existingBranchNames,
+}: {
+  token: string
+  owner: string
+  repo: string
+  baseBranch: string
+  scope: string
+  existingBranchNames: string[]
+}) {
+  const takenBranchNames = new Set(existingBranchNames)
+
+  for (let ordinal = 1; ordinal <= 50; ordinal += 1) {
+    const candidate = buildPublishBranchName(scope, ordinal)
+    if (takenBranchNames.has(candidate)) continue
+
+    const alreadyExists = await branchExists(token, owner, repo, candidate)
+    if (alreadyExists) {
+      takenBranchNames.add(candidate)
+      continue
+    }
+
+    try {
+      await createBranch(token, owner, repo, baseBranch, candidate)
+      return candidate
+    } catch (error) {
+      if (isGitHubBranchExistsError(error)) {
+        takenBranchNames.add(candidate)
+        continue
+      }
+      throw error
+    }
+  }
+
+  throw new Error(`Failed to allocate a publish branch name for scope "${scope}"`)
+}
+
+function isGitHubBranchExistsError(error: unknown) {
+  if (error instanceof Error && /already exists/i.test(error.message)) return true
+  return typeof error === "object" && error !== null && "status" in error && error.status === 422
 }
 
 async function cleanupOrphanedPublishBranch({

--- a/app/api/github/publish-ops/route.ts
+++ b/app/api/github/publish-ops/route.ts
@@ -5,7 +5,14 @@ import { api } from "@/convex/_generated/api"
 import type { Id } from "@/convex/_generated/dataModel"
 import { prefixContentRoot } from "@/lib/explorer-tree-overlay"
 import type { BatchOperation } from "@/lib/github"
-import { batchCommit, createBranch, createGitHubClient, createPullRequest, getFile } from "@/lib/github"
+import {
+  batchCommit,
+  createBranch,
+  createGitHubClient,
+  createPullRequest,
+  getFile,
+  updatePullRequest,
+} from "@/lib/github"
 import { mintServerQueryToken } from "@/lib/project-access-token"
 import { RouteAuthError, resolveRouteAuth } from "@/lib/route-auth"
 import { isStudioMediaResolveUrl } from "@/lib/studio/media-resolve"
@@ -239,8 +246,8 @@ export async function POST(request: Request) {
     }
 
     // If no active branch exists, create a new publish branch with timestamp-based name.
-    // Branch naming: repopress/${baseBranch}/${timestamp} e.g., repopress/main/1710681600000
-    const branchName = publishBranch?.branchName || `repopress/${baseBranch}/${Date.now()}`
+    // Branch naming: repopress/publish/${baseBranch}/${timestamp}
+    const branchName = publishBranch?.branchName || `repopress/publish/${baseBranch}/${Date.now()}`
 
     if (!publishBranch) {
       await createBranch(token, owner, repo, baseBranch, branchName)
@@ -298,14 +305,25 @@ export async function POST(request: Request) {
     // This is intentional - additional publishes will update the same PR with new commits.
     let prUrl = publishBranch.prUrl
     let prNumber = publishBranch.prNumber
+    let warning: string | undefined
 
     if (!prNumber) {
-      const prTitle = title || `Content update via RepoPress (${parts.join(", ")})`
+      const prTitle = title || `Content update via RepoPress (${parts.join(", ")}) (PR from RepoPress)`
       const prBody =
         description || `Automated content update from RepoPress.\n\n${parts.map((p) => `- ${p}`).join("\n")}`
       const pr = await createPullRequest(token, owner, repo, branchName, baseBranch, prTitle, prBody)
       prNumber = pr.number
       prUrl = pr.htmlUrl
+    } else if (title || description) {
+      try {
+        await updatePullRequest(token, owner, repo, prNumber, {
+          title: title || undefined,
+          body: description || undefined,
+        })
+      } catch (error) {
+        warning = "Commit pushed, but updating the existing PR title/description failed."
+        console.error("Failed to update existing PR metadata:", error)
+      }
     }
 
     await convex.mutation(api.publishBranches.updateAfterCommit, {
@@ -372,6 +390,7 @@ export async function POST(request: Request) {
       publishModeUsed,
       commitSha,
       summary: parts.join(", "),
+      warning,
       media: {
         created: mediaCreateCount,
         updated: mediaUpdateCount,

--- a/components/studio/__tests__/publish-dialog.test.tsx
+++ b/components/studio/__tests__/publish-dialog.test.tsx
@@ -54,4 +54,52 @@ describe("PublishDialog", () => {
     expect(html.toLowerCase()).toContain("media")
     expect(html).toContain("2 media")
   })
+
+  it("shows PR fields when reusing the current publish lane", () => {
+    const html = renderToStaticMarkup(
+      <PublishDialog
+        open
+        onOpenChange={vi.fn()}
+        pendingCounts={
+          {
+            creates: 0,
+            deletes: 0,
+            edits: 1,
+            media: 0,
+          } as any
+        }
+        publishLaneViewModel={
+          {
+            currentLane: {
+              prNumber: 42,
+              prUrl: "https://github.com/acme/docs-site/pull/42",
+              title: "Current PR #42",
+              summary: "New publishes will update PR #42.",
+              linkLabel: "PR #42",
+            },
+            modeOptions: {
+              "create-new": {
+                label: "Create a new pull request",
+                description: "Create a new publish lane and PR.",
+                submitLabel: "Create PR",
+              },
+              "reuse-current": {
+                label: "Update current pull request",
+                description: "Add changes to the current lane.",
+                submitLabel: "Update PR",
+              },
+            },
+          } as any
+        }
+        publishMode="reuse-current"
+        onPublishModeChange={vi.fn()}
+        isPublishing={false}
+        onConfirm={vi.fn()}
+      />,
+    )
+
+    expect(html).toContain("Current PR #42")
+    expect(html).toContain("PR Title")
+    expect(html).toContain("Description (optional)")
+  })
 })

--- a/components/studio/hooks/__tests__/use-studio-publish.test.tsx
+++ b/components/studio/hooks/__tests__/use-studio-publish.test.tsx
@@ -1,0 +1,78 @@
+import type * as React from "react"
+import { renderToStaticMarkup } from "react-dom/server"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const { saveDraftMutationMock, toastMock } = vi.hoisted(() => {
+  const toastFn = Object.assign(vi.fn(), {
+    success: vi.fn(),
+    error: vi.fn(),
+  })
+
+  return {
+    saveDraftMutationMock: vi.fn(),
+    toastMock: toastFn,
+  }
+})
+
+vi.mock("convex/react", () => ({
+  useMutation: vi.fn(() => saveDraftMutationMock),
+}))
+
+vi.mock("sonner", () => ({
+  toast: toastMock,
+}))
+
+vi.mock("../../studio-context", () => ({
+  useStudio: () => ({ projectId: "project_123" }),
+}))
+
+import { useStudioPublish } from "../use-studio-publish"
+
+describe("useStudioPublish", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    saveDraftMutationMock.mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("surfaces publish warnings while still showing the success toast", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValue({
+        ok: true,
+        prUrl: "https://github.com/acme/docs-site/pull/42",
+        warning: "Commit pushed, but updating the existing PR title/description failed.",
+      }),
+    } as never)
+
+    let hookState: ReturnType<typeof useStudioPublish> | null = null
+
+    function Harness() {
+      hookState = useStudioPublish({
+        userId: "user_owner",
+        projectAccessToken: null,
+        documentUpdatedAt: null,
+        ensureDocumentRecord: vi.fn().mockResolvedValue(null),
+        selectedFile: null,
+        content: "# Hello",
+        frontmatter: {},
+        defaultPublishMode: "reuse-current",
+      })
+      return null
+    }
+
+    renderToStaticMarkup(<Harness />)
+
+    expect(hookState).not.toBeNull()
+
+    await hookState!.handlePublish("docs: tighten publish UX (PR from RepoPress)", "Refresh publish copy.")
+
+    expect(fetchMock).toHaveBeenCalled()
+    expect(toastMock.success).toHaveBeenCalledWith("Pushed to PR")
+    expect(toastMock).toHaveBeenCalledWith("Commit pushed, but updating the existing PR title/description failed.")
+  })
+})

--- a/components/studio/hooks/use-studio-publish.ts
+++ b/components/studio/hooks/use-studio-publish.ts
@@ -80,6 +80,9 @@ export function useStudioPublish({
         if (!response.ok) throw new Error(data.error || "Failed to publish")
 
         toast.success(data.prUrl ? "Pushed to PR" : "Published")
+        if (typeof data.warning === "string" && data.warning.length > 0) {
+          toast(data.warning)
+        }
         setPublishDialogOpen(false)
       } catch (error: any) {
         console.error("Error publishing:", error)

--- a/components/studio/publish-dialog.tsx
+++ b/components/studio/publish-dialog.tsx
@@ -190,35 +190,38 @@ export function PublishDialog({
           </div>
         )}
 
-        {/* PR Form (new PR only) */}
-        {isCreateNewMode && (
-          <div className="space-y-4">
-            <div>
-              <Label htmlFor="prTitle" className="text-sm font-medium">
-                PR Title
-              </Label>
-              <Input
-                id="prTitle"
-                value={title}
-                onChange={(e) => setTitle(e.target.value)}
-                placeholder={`Content update: ${summaryParts.join(", ")}`}
-                className="mt-1.5 border-studio-border"
-              />
-            </div>
-            <div>
-              <Label htmlFor="prDescription" className="text-sm font-medium">
-                Description (optional)
-              </Label>
-              <Textarea
-                id="prDescription"
-                value={description}
-                onChange={(e) => setDescription(e.target.value)}
-                placeholder="Describe your changes..."
-                className="mt-1.5 h-20 border-studio-border resize-none"
-              />
-            </div>
+        <div className="space-y-4">
+          <div>
+            <Label htmlFor="prTitle" className="text-sm font-medium">
+              PR Title
+            </Label>
+            <Input
+              id="prTitle"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder={
+                isCreateNewMode
+                  ? `Content update: ${summaryParts.join(", ")}`
+                  : currentLane?.prNumber
+                    ? `Optional update for PR #${currentLane.prNumber}`
+                    : "Optional PR title update"
+              }
+              className="mt-1.5 border-studio-border"
+            />
           </div>
-        )}
+          <div>
+            <Label htmlFor="prDescription" className="text-sm font-medium">
+              Description (optional)
+            </Label>
+            <Textarea
+              id="prDescription"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder={isCreateNewMode ? "Describe your changes..." : "Optional update for the current PR body..."}
+              className="mt-1.5 h-20 border-studio-border resize-none"
+            />
+          </div>
+        </div>
 
         <DialogFooter>
           <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isPublishing}>

--- a/convex/publishBranches.ts
+++ b/convex/publishBranches.ts
@@ -63,6 +63,25 @@ export const listOpenForProject = query({
   },
 })
 
+/** Lists every publish branch name a project has already used. */
+export const listBranchNamesForProject = query({
+  args: {
+    projectId: v.id("projects"),
+    userId: v.optional(v.string()),
+    projectAccessToken: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const access = await resolveProjectReader(ctx, args)
+    if (!access) return []
+
+    const branches = await ctx.db
+      .query("publishBranches")
+      .withIndex("by_projectId", (q) => q.eq("projectId", args.projectId))
+      .collect()
+    return branches.map((branch) => branch.branchName)
+  },
+})
+
 /** Finds a publish branch by its PR number. Used by webhook handlers. */
 export const getByPRNumber = query({
   args: { prNumber: v.number() },

--- a/lib/__tests__/publish-branch-lanes.test.ts
+++ b/lib/__tests__/publish-branch-lanes.test.ts
@@ -20,7 +20,13 @@ vi.mock("@/convex/auth", () => ({
 
 import { markCommitted as markExplorerOpsCommitted } from "@/convex/explorerOps"
 import { markCommitted as markMediaOpsCommitted } from "@/convex/mediaOps"
-import { create, deactivateCurrentForProject, getCurrentForProject, listOpenForProject } from "@/convex/publishBranches"
+import {
+  create,
+  deactivateCurrentForProject,
+  getCurrentForProject,
+  listBranchNamesForProject,
+  listOpenForProject,
+} from "@/convex/publishBranches"
 
 function createProject() {
   return {
@@ -198,6 +204,35 @@ describe("Publish branch lanes", () => {
       "publish_branch_current",
       "publish_branch_inactive",
     ])
+  })
+
+  it("lists all publish branch names for collision checks", async () => {
+    const ctx = createCtx({
+      get: vi.fn().mockResolvedValue(createProject()),
+      query: vi.fn().mockReturnValue({
+        withIndex: () => ({
+          collect: vi.fn().mockResolvedValue([
+            {
+              _id: "publish_branch_current",
+              projectId: "project_1",
+              branchName: "repopress/hello",
+            },
+            {
+              _id: "publish_branch_inactive",
+              projectId: "project_1",
+              branchName: "repopress/hello-2",
+            },
+          ]),
+        }),
+      }),
+    })
+
+    const result = await (listBranchNamesForProject as any).handler(ctx, {
+      projectId: "project_1",
+      userId: "user_owner",
+    })
+
+    expect(result).toEqual(["repopress/hello", "repopress/hello-2"])
   })
 
   it("stores publishBranchId on committed explorer ops", async () => {

--- a/lib/__tests__/publish-branch-name.test.ts
+++ b/lib/__tests__/publish-branch-name.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from "vitest"
+import { buildPublishBranchName } from "../publish-branch-name"
+
+describe("buildPublishBranchName", () => {
+  it("builds a readable publish branch suffix with a stable UTC timestamp token", () => {
+    expect(buildPublishBranchName("main", 1_700_000_000_000)).toBe("repopress/publish/main/2023-11-14-221320-loyw3v28")
+  })
+})

--- a/lib/__tests__/publish-branch-name.test.ts
+++ b/lib/__tests__/publish-branch-name.test.ts
@@ -1,8 +1,30 @@
 import { describe, expect, it } from "vitest"
-import { buildPublishBranchName } from "../publish-branch-name"
+import { buildPublishBranchName, derivePublishBranchScope } from "../publish-branch-name"
+
+describe("derivePublishBranchScope", () => {
+  it("uses the changed file slug when only one file changed", () => {
+    expect(derivePublishBranchScope(["content/posts/hello-world.mdx"], "content")).toBe("hello-world")
+  })
+
+  it("uses the shared area label when multiple files changed in one area", () => {
+    expect(
+      derivePublishBranchScope(["content/posts/hello-world.mdx", "content/posts/another-post.mdx"], "content"),
+    ).toBe("posts")
+  })
+
+  it("falls back to multi-change when changes span multiple areas", () => {
+    expect(derivePublishBranchScope(["content/posts/hello-world.mdx", "public/images/blog/cover.png"], "content")).toBe(
+      "multi-change",
+    )
+  })
+})
 
 describe("buildPublishBranchName", () => {
-  it("builds a readable publish branch suffix with a stable UTC timestamp token", () => {
-    expect(buildPublishBranchName("main", 1_700_000_000_000)).toBe("repopress/publish/main/2023-11-14-221320-loyw3v28")
+  it("builds the first branch name without an ordinal suffix", () => {
+    expect(buildPublishBranchName("hello-world")).toBe("repopress/hello-world")
+  })
+
+  it("appends an ordinal suffix when a scope name collides", () => {
+    expect(buildPublishBranchName("hello-world", 2)).toBe("repopress/hello-world-2")
   })
 })

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -485,6 +485,22 @@ export async function createPullRequest(
   return { number: data.number, url: data.url, htmlUrl: data.html_url }
 }
 
+export async function updatePullRequest(
+  accessToken: string,
+  owner: string,
+  repo: string,
+  pullNumber: number,
+  updates: { title?: string; body?: string },
+): Promise<void> {
+  const octokit = createGitHubClient(accessToken)
+  await octokit.pulls.update({
+    owner,
+    repo,
+    pull_number: pullNumber,
+    ...updates,
+  })
+}
+
 export async function getPullRequest(
   accessToken: string,
   owner: string,

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -356,6 +356,24 @@ export async function createBranch(
   return data
 }
 
+export async function branchExists(accessToken: string, owner: string, repo: string, branchName: string) {
+  const octokit = createGitHubClient(accessToken)
+
+  try {
+    await octokit.git.getRef({
+      owner,
+      repo,
+      ref: `heads/${branchName}`,
+    })
+    return true
+  } catch (error: any) {
+    if (error?.status === 404) {
+      return false
+    }
+    throw error
+  }
+}
+
 export type BatchOperation = {
   path: string
   content?: string

--- a/lib/publish-branch-name.ts
+++ b/lib/publish-branch-name.ts
@@ -1,13 +1,72 @@
-export function buildPublishBranchName(baseBranch: string, now: number | Date = Date.now()) {
-  const date = typeof now === "number" ? new Date(now) : now
+import { posix as path } from "node:path"
+import { slugify } from "./slug"
 
-  const year = date.getUTCFullYear()
-  const month = String(date.getUTCMonth() + 1).padStart(2, "0")
-  const day = String(date.getUTCDate()).padStart(2, "0")
-  const hours = String(date.getUTCHours()).padStart(2, "0")
-  const minutes = String(date.getUTCMinutes()).padStart(2, "0")
-  const seconds = String(date.getUTCSeconds()).padStart(2, "0")
-  const uniqueSuffix = date.getTime().toString(36)
+const DEFAULT_SCOPE = "multi-change"
+const AREA_PREFIXES = new Set(["assets", "content", "images", "img", "media", "public", "static", "uploads"])
+const RESERVED_FILE_STEMS = new Set(["index", "page", "readme"])
+const MAX_SCOPE_LENGTH = 40
 
-  return `repopress/publish/${baseBranch}/${year}-${month}-${day}-${hours}${minutes}${seconds}-${uniqueSuffix}`
+export function derivePublishBranchScope(paths: string[], contentRoot = "") {
+  const uniquePaths = [...new Set(paths.map((value) => normalizePath(value)).filter(Boolean))]
+  if (uniquePaths.length === 0) return DEFAULT_SCOPE
+  if (uniquePaths.length === 1) return deriveSingleFileScope(uniquePaths[0], contentRoot)
+
+  const areaLabels = [...new Set(uniquePaths.map((value) => deriveAreaScope(value, contentRoot)))]
+  return areaLabels.length === 1 && areaLabels[0] !== DEFAULT_SCOPE ? areaLabels[0] : DEFAULT_SCOPE
+}
+
+export function buildPublishBranchName(scope: string, ordinal = 1) {
+  const normalizedScope = clampScope(scope)
+  return ordinal <= 1 ? `repopress/${normalizedScope}` : `repopress/${normalizedScope}-${ordinal}`
+}
+
+function deriveSingleFileScope(filePath: string, contentRoot: string) {
+  const segments = stripContentRoot(filePath, contentRoot).split("/").filter(Boolean)
+  if (segments.length === 0) return DEFAULT_SCOPE
+
+  const fileName = segments[segments.length - 1]
+  let scopeSource = path.parse(fileName).name
+  if (RESERVED_FILE_STEMS.has(scopeSource.toLowerCase()) && segments.length > 1) {
+    scopeSource = segments[segments.length - 2]
+  }
+
+  return clampScope(scopeSource)
+}
+
+function deriveAreaScope(filePath: string, contentRoot: string) {
+  let segments = stripContentRoot(filePath, contentRoot).split("/").filter(Boolean)
+  while (segments.length > 1 && AREA_PREFIXES.has(segments[0].toLowerCase())) {
+    segments = segments.slice(1)
+  }
+
+  if (segments.length < 2) return DEFAULT_SCOPE
+  return clampScope(segments[0])
+}
+
+function stripContentRoot(filePath: string, contentRoot: string) {
+  const normalizedPath = normalizePath(filePath)
+  const normalizedRoot = normalizePath(contentRoot)
+
+  if (!normalizedRoot) return normalizedPath
+  if (normalizedPath === normalizedRoot) return ""
+  if (normalizedPath.startsWith(`${normalizedRoot}/`)) {
+    return normalizedPath.slice(normalizedRoot.length + 1)
+  }
+
+  return normalizedPath
+}
+
+function clampScope(value: string) {
+  const slug = slugify(value)
+  if (slug.length <= MAX_SCOPE_LENGTH) return slug
+  const shortened = slug.slice(0, MAX_SCOPE_LENGTH).replace(/-+$/g, "")
+  return shortened || DEFAULT_SCOPE
+}
+
+function normalizePath(value: string) {
+  return value
+    .replace(/\\/g, "/")
+    .replace(/^\/+/, "")
+    .replace(/\/{2,}/g, "/")
+    .replace(/\/+$/, "")
 }

--- a/lib/publish-branch-name.ts
+++ b/lib/publish-branch-name.ts
@@ -1,0 +1,13 @@
+export function buildPublishBranchName(baseBranch: string, now: number | Date = Date.now()) {
+  const date = typeof now === "number" ? new Date(now) : now
+
+  const year = date.getUTCFullYear()
+  const month = String(date.getUTCMonth() + 1).padStart(2, "0")
+  const day = String(date.getUTCDate()).padStart(2, "0")
+  const hours = String(date.getUTCHours()).padStart(2, "0")
+  const minutes = String(date.getUTCMinutes()).padStart(2, "0")
+  const seconds = String(date.getUTCSeconds()).padStart(2, "0")
+  const uniqueSuffix = date.getTime().toString(36)
+
+  return `repopress/publish/${baseBranch}/${year}-${month}-${day}-${hours}${minutes}${seconds}-${uniqueSuffix}`
+}


### PR DESCRIPTION
## Summary
- switch default publish branches to repopress/publish/<base>/<timestamp> and brand create-new PR titles with the RepoPress marker
- let reuse-current publish flows update existing PR title/body and return partial-success warnings if GitHub metadata updates fail after the commit push
- expose PR title/description fields in both publish modes and surface backend warning responses in the studio publish hook