### PR TITLE
feat(landing): add lazy-loaded Remotion demo preview

### DIFF
--- a/app/__tests__/page.test.tsx
+++ b/app/__tests__/page.test.tsx
@@ -1,0 +1,54 @@
+import { renderToStaticMarkup } from "react-dom/server"
+import { describe, expect, it, vi } from "vitest"
+
+vi.mock("@/components/landing/navbar", () => ({
+  default: () => <div data-slot="navbar" />,
+}))
+
+vi.mock("@/components/landing/hero", () => ({
+  default: () => <section data-slot="hero" />,
+}))
+
+vi.mock("@/components/landing/video-preview", () => ({
+  VideoPreview: () => <section data-slot="video-preview" />,
+}))
+
+vi.mock("@/components/landing/how-it-works", () => ({
+  default: () => <section data-slot="how-it-works" />,
+}))
+
+vi.mock("@/components/landing/feature-grid", () => ({
+  default: () => <section data-slot="feature-grid" />,
+}))
+
+vi.mock("@/components/landing/comparison", () => ({
+  default: () => <section data-slot="comparison" />,
+}))
+
+vi.mock("@/components/landing/faq", () => ({
+  default: () => <section data-slot="faq" />,
+}))
+
+vi.mock("@/components/landing/pricing", () => ({
+  default: () => <section data-slot="pricing" />,
+}))
+
+vi.mock("@/components/landing/cta", () => ({
+  default: () => <section data-slot="cta" />,
+}))
+
+vi.mock("@/components/landing/footer", () => ({
+  default: () => <div data-slot="footer" />,
+}))
+
+import LandingPage from "../page"
+
+describe("LandingPage", () => {
+  it("renders the video preview between the hero and how-it-works sections", () => {
+    const html = renderToStaticMarkup(<LandingPage />)
+
+    expect(html).toContain('data-slot="video-preview"')
+    expect(html.indexOf('data-slot="hero"')).toBeLessThan(html.indexOf('data-slot="video-preview"'))
+    expect(html.indexOf('data-slot="video-preview"')).toBeLessThan(html.indexOf('data-slot="how-it-works"'))
+  })
+})

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,6 +7,7 @@ import Hero from "@/components/landing/hero"
 import HowItWorks from "@/components/landing/how-it-works"
 import Navbar from "@/components/landing/navbar"
 import Pricing from "@/components/landing/pricing"
+import { VideoPreview } from "@/components/landing/video-preview"
 
 export default function LandingPage() {
   return (
@@ -14,6 +15,7 @@ export default function LandingPage() {
       <Navbar />
       <main className="flex-1">
         <Hero />
+        <VideoPreview />
         <HowItWorks />
         <FeatureGrid />
         <Comparison />

--- a/components/landing/__tests__/video-preview.test.tsx
+++ b/components/landing/__tests__/video-preview.test.tsx
@@ -1,0 +1,23 @@
+import { renderToStaticMarkup } from "react-dom/server"
+import { describe, expect, it } from "vitest"
+import * as StudioDemoModule from "@/remotion/compositions/StudioDemo"
+import { VideoPreview } from "../video-preview"
+
+describe("landing video preview", () => {
+  it("renders a sized placeholder shell before the player is activated", () => {
+    const html = renderToStaticMarkup(<VideoPreview />)
+
+    expect(html).toContain("See RepoPress in action")
+    expect(html).toContain('data-video-preview-placeholder="idle"')
+  })
+
+  it("exports shared StudioDemo composition metadata for preview consumers", () => {
+    expect(StudioDemoModule).toHaveProperty("studioDemoComposition")
+    expect(StudioDemoModule.studioDemoComposition).toMatchObject({
+      durationInFrames: 300,
+      fps: 30,
+      width: 1280,
+      height: 720,
+    })
+  })
+})

--- a/components/landing/video-preview-player.tsx
+++ b/components/landing/video-preview-player.tsx
@@ -1,0 +1,22 @@
+"use client"
+
+import { Player } from "@remotion/player"
+import { StudioDemo } from "@/remotion/compositions/StudioDemo"
+import { studioDemoComposition } from "@/remotion/compositions/studio-demo-composition"
+
+export function VideoPreviewPlayer() {
+  return (
+    <Player
+      acknowledgeRemotionLicense
+      autoPlay
+      component={StudioDemo}
+      compositionHeight={studioDemoComposition.height}
+      compositionWidth={studioDemoComposition.width}
+      controls={false}
+      durationInFrames={studioDemoComposition.durationInFrames}
+      fps={studioDemoComposition.fps}
+      loop
+      style={{ display: "block", width: "100%" }}
+    />
+  )
+}

--- a/components/landing/video-preview.tsx
+++ b/components/landing/video-preview.tsx
@@ -1,22 +1,90 @@
 "use client"
 
-import { Player } from "@remotion/player"
-import { StudioDemo } from "@/remotion/compositions/StudioDemo"
+import { LoaderCircle, PlayCircle } from "lucide-react"
+import dynamic from "next/dynamic"
+import { useEffect, useRef, useState } from "react"
+import { studioDemoComposition } from "@/remotion/compositions/studio-demo-composition"
+
+const VideoPreviewPlayer = dynamic(() => import("./video-preview-player").then((mod) => mod.VideoPreviewPlayer), {
+  ssr: false,
+  loading: () => <VideoPreviewPlaceholder state="loading" />,
+})
 
 export function VideoPreview() {
+  const sectionRef = useRef<HTMLElement | null>(null)
+  const [shouldRenderPlayer, setShouldRenderPlayer] = useState(false)
+
+  useEffect(() => {
+    if (shouldRenderPlayer) {
+      return
+    }
+
+    if (typeof IntersectionObserver === "undefined") {
+      setShouldRenderPlayer(true)
+      return
+    }
+
+    const node = sectionRef.current
+    if (!node) {
+      return
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry?.isIntersecting) {
+          setShouldRenderPlayer(true)
+          observer.disconnect()
+        }
+      },
+      { rootMargin: "240px 0px" },
+    )
+
+    observer.observe(node)
+
+    return () => observer.disconnect()
+  }, [shouldRenderPlayer])
+
   return (
-    <div className="mx-auto max-w-4xl overflow-hidden rounded-xl border border-border shadow-2xl">
-      <Player
-        component={StudioDemo}
-        durationInFrames={300}
-        compositionWidth={1280}
-        compositionHeight={720}
-        fps={30}
-        autoPlay
-        loop
-        style={{ width: "100%" }}
-        controls={false}
-      />
+    <section ref={sectionRef} id="demo" data-slot="landing-video-preview" className="container mx-auto px-4 py-24">
+      <div className="mx-auto flex max-w-[58rem] flex-col items-center space-y-4 text-center">
+        <p className="font-mono text-[11px] font-medium uppercase tracking-[0.04em] text-muted-foreground">
+          Product demo
+        </p>
+        <h2 className="text-3xl font-semibold tracking-tight md:text-4xl">See RepoPress in action</h2>
+        <p className="max-w-[48rem] text-balance text-muted-foreground sm:text-lg sm:leading-7">
+          Watch the studio workflow loop through repository setup, editing, review, and publish without loading the full
+          player until the demo enters view.
+        </p>
+      </div>
+
+      <div className="mx-auto mt-10 max-w-5xl overflow-hidden rounded-[10px] border border-border bg-card">
+        {shouldRenderPlayer ? <VideoPreviewPlayer /> : <VideoPreviewPlaceholder state="idle" />}
+      </div>
+    </section>
+  )
+}
+
+function VideoPreviewPlaceholder({ state }: { state: "idle" | "loading" }) {
+  const Icon = state === "loading" ? LoaderCircle : PlayCircle
+  const label = state === "loading" ? "Loading studio demo..." : "Studio demo loads when this section enters view."
+
+  return (
+    <div
+      data-video-preview-placeholder={state}
+      className="flex w-full items-center justify-center bg-muted/40"
+      style={{ aspectRatio: `${studioDemoComposition.width} / ${studioDemoComposition.height}` }}
+    >
+      <div className="flex max-w-md flex-col items-center gap-4 px-6 text-center">
+        <div className="flex h-12 w-12 items-center justify-center rounded-full border border-border bg-background">
+          <Icon className={state === "loading" ? "h-5 w-5 animate-spin text-foreground" : "h-5 w-5 text-foreground"} />
+        </div>
+        <div className="space-y-2">
+          <p className="text-sm font-medium text-foreground">{label}</p>
+          <p className="text-sm text-muted-foreground">
+            The placeholder keeps the 16:9 frame stable so the landing page does not jump as the preview mounts.
+          </p>
+        </div>
+      </div>
     </div>
   )
 }

--- a/remotion/Root.tsx
+++ b/remotion/Root.tsx
@@ -4,6 +4,7 @@ import { GitNativeFeature } from "./compositions/GitNativeFeature"
 import { LaunchVideo, launchVideoDefaultProps } from "./compositions/LaunchVideo"
 import { MDXEditorFeature } from "./compositions/MDXEditorFeature"
 import { StudioDemo } from "./compositions/StudioDemo"
+import { studioDemoComposition } from "./compositions/studio-demo-composition"
 import { TutorialVideo, tutorialVideoDefaultProps } from "./compositions/TutorialVideo"
 import { WorkflowFeature } from "./compositions/WorkflowFeature"
 
@@ -11,7 +12,14 @@ export const RemotionRoot = () => {
   return (
     <>
       {/* ── Feature compositions (building blocks) ─────────────────────── */}
-      <Composition id="StudioDemo" component={StudioDemo} durationInFrames={300} fps={30} width={1280} height={720} />
+      <Composition
+        id={studioDemoComposition.id}
+        component={StudioDemo}
+        durationInFrames={studioDemoComposition.durationInFrames}
+        fps={studioDemoComposition.fps}
+        width={studioDemoComposition.width}
+        height={studioDemoComposition.height}
+      />
       <Composition
         id="GitNativeFeature"
         component={GitNativeFeature}

--- a/remotion/compositions/StudioDemo.tsx
+++ b/remotion/compositions/StudioDemo.tsx
@@ -1,6 +1,8 @@
 import { AbsoluteFill, interpolate, Sequence, spring, useCurrentFrame, useVideoConfig } from "remotion"
 import { geistFamily, geistMonoFamily } from "../fonts"
 
+export { studioDemoComposition } from "./studio-demo-composition"
+
 const ACCENT = "#3b82f6"
 const BG = "#000000"
 const FG = "#ffffff"

--- a/remotion/compositions/studio-demo-composition.ts
+++ b/remotion/compositions/studio-demo-composition.ts
@@ -1,0 +1,7 @@
+export const studioDemoComposition = {
+  id: "StudioDemo",
+  durationInFrames: 300,
+  fps: 30,
+  width: 1280,
+  height: 720,
+} as const


### PR DESCRIPTION
## Summary
- wire the landing page to render the Remotion demo section right after Hero
- split the landing preview into an in-view lazy shell plus a client-only `@remotion/player` module
- share `StudioDemo` composition metadata between the landing preview and Remotion root, and add regression tests for the new wiring

## Verification
- `npx biome check app/page.tsx app/__tests__/page.test.tsx components/landing/video-preview.tsx components/landing/video-preview-player.tsx components/landing/__tests__/video-preview.test.tsx remotion/Root.tsx remotion/compositions/StudioDemo.tsx remotion/compositions/studio-demo-composition.ts`
- `npm test`
- `NEXT_PUBLIC_CONVEX_URL=https://placeholder.invalid NEXT_PUBLIC_CONVEX_SITE_URL=https://placeholder.invalid CONVEX_DEPLOYMENT=dev:placeholder npm run build`
- local browser QA on `http://127.0.0.1:3002` (landing demo section mounted between Hero and How It Works, placeholder handoff to a single Remotion player verified)

## Notes
- repo-wide `npm run lint` still hits the pre-existing Biome issue in `components/studio/gallery-tab.tsx` on this branch base; this change keeps the touched files clean instead of expanding scope to unrelated code.