### PR TITLE
fix: harden production auth, recovery, and preview isolation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -331,7 +331,7 @@ npx convex dev  # in another terminal
 
 ### Troubleshooting
 - **"ConvexReactClient not initialized"** → `NEXT_PUBLIC_CONVEX_URL` is missing
-- **"OAuth callback failed"** → GitHub OAuth App callback URL must be `https://your-convex-project.convex.site/api/auth/callback/github`
+- **"OAuth callback failed"** → GitHub OAuth App callback URL must be `https://your-app.example/api/auth/callback/github`
 - **"ctx is not a mutation context"** → Auth.ts was edited incorrectly; reset from git
 
 ## Common Pitfalls

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -310,7 +310,7 @@ Example: "I need `NEXT_PUBLIC_CONVEX_URL` to complete this task. Please provide 
 - `GITHUB_CLIENT_SECRET` – GitHub OAuth App client secret
 - `BETTER_AUTH_SECRET` – Random secret for session encryption
 - `REPOPRESS_CAPABILITY_SECRET` – Separate 32+ character signing secret; set the same value in Convex and the Next.js runtime
-- `SITE_URL` – Your Convex site URL
+- `SITE_URL` – Public RepoPress application origin used by Better Auth callbacks
 
 ### Optional
 - `NEXT_PUBLIC_APP_URL` – Public app URL

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -319,7 +319,7 @@ Never read `.env.local`, `.env`, or other secrets files directly. If a task need
 - `GITHUB_CLIENT_SECRET` -- GitHub OAuth App client secret
 - `BETTER_AUTH_SECRET` -- Random secret for session encryption
 - `REPOPRESS_CAPABILITY_SECRET` -- Separate 32+ character signing secret; set the same value in Convex and the Next.js runtime
-- `SITE_URL` -- Your Convex site URL (same as NEXT_PUBLIC_CONVEX_SITE_URL)
+- `SITE_URL` -- Public RepoPress application origin used by Better Auth callbacks
 
 ### Optional:
 - `NEXT_PUBLIC_APP_URL` -- Your app's public URL

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -319,7 +319,7 @@ Never read `.env.local`, `.env`, or other secrets files directly. If a task need
 - `GITHUB_CLIENT_SECRET` -- GitHub OAuth App client secret
 - `BETTER_AUTH_SECRET` -- Random secret for session encryption
 - `REPOPRESS_CAPABILITY_SECRET` -- Separate 32+ character signing secret; set the same value in Convex and the Next.js runtime
-- `SITE_URL` -- Your Convex site URL (same as NEXT_PUBLIC_CONVEX_SITE_URL)
+- `SITE_URL` -- Public RepoPress application origin used by Better Auth callbacks
 
 ### Optional:
 - `NEXT_PUBLIC_APP_URL` -- Your app's public URL

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ New repository setup uses native discovery: RepoPress inspects the repository's 
 | `GITHUB_CLIENT_SECRET` | From your GitHub OAuth App |
 | `BETTER_AUTH_SECRET` | Random secret string for session encryption |
 | `REPOPRESS_CAPABILITY_SECRET` | Random 32+ character capability-signing secret; use the same value in the Next.js runtime |
-| `SITE_URL` | Your Convex site URL (same as `NEXT_PUBLIC_CONVEX_SITE_URL`) |
+| `SITE_URL` | Public RepoPress application origin used by Better Auth (for example, `https://repopress.example`) |
 
 ### Next.js runtime
 
@@ -167,6 +167,7 @@ New repository setup uses native discovery: RepoPress inspects the repository's 
 |---|---|
 | `REPOPRESS_CAPABILITY_SECRET` | Same capability-signing value configured in Convex; never reuse `BETTER_AUTH_SECRET` |
 | `PREVIEW_APPROVAL_PRIVATE_KEY_JWK` | Server-only EC P-256 private JWK used to sign Compatible preview artifacts; never expose or log it |
+| `REPOPRESS_DEPLOYMENT_ROLE` | Set to `sandbox` only on the separately hosted Compatible preview project; omit on Studio |
 
 ### Compatible preview browser configuration
 

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ The private and public preview JWKs must be generated as one P-256 key pair. Kee
 1. Go to [GitHub Developer Settings](https://github.com/settings/developers)
 2. Click **New OAuth App**
 3. Set **Homepage URL** to your app URL
-4. Set **Authorization callback URL** to `https://your-convex-project.convex.site/api/auth/callback/github`
+4. Set **Authorization callback URL** to `https://your-app.example/api/auth/callback/github`
 5. Copy the Client ID and generate a Client Secret
 
 ---

--- a/app/dashboard/error.tsx
+++ b/app/dashboard/error.tsx
@@ -4,13 +4,7 @@ import * as Sentry from "@sentry/nextjs"
 import { useEffect } from "react"
 import { ErrorRecovery } from "@/components/error-recovery"
 
-export default function DashboardError({
-  error,
-  reset,
-}: {
-  error: Error & { digest?: string }
-  reset: () => void
-}) {
+export default function DashboardError({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
   useEffect(() => {
     Sentry.captureException(error)
   }, [error])

--- a/app/dashboard/error.tsx
+++ b/app/dashboard/error.tsx
@@ -1,0 +1,19 @@
+"use client"
+
+import * as Sentry from "@sentry/nextjs"
+import { useEffect } from "react"
+import { ErrorRecovery } from "@/components/error-recovery"
+
+export default function DashboardError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  useEffect(() => {
+    Sentry.captureException(error)
+  }, [error])
+
+  return <ErrorRecovery onRetry={reset} digest={error.digest} />
+}

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -2,6 +2,7 @@
 
 import * as Sentry from "@sentry/nextjs"
 import { useEffect } from "react"
+import { ErrorRecovery } from "@/components/error-recovery"
 
 export default function GlobalError({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
   useEffect(() => {
@@ -9,14 +10,16 @@ export default function GlobalError({ error, reset }: { error: Error & { digest?
   }, [error])
 
   return (
-    <html lang="en">
-      <body>
-        <div style={{ padding: "2rem", textAlign: "center" }}>
-          <h2>Something went wrong</h2>
-          <button type="button" onClick={() => reset()}>
-            Try again
-          </button>
-        </div>
+    <html lang="en" className="bg-background">
+      <body className="min-h-svh bg-background font-sans text-foreground antialiased">
+        <ErrorRecovery
+          onRetry={reset}
+          title="We couldn't open RepoPress"
+          description="The application hit an unexpected problem. Your saved content and files in GitHub are safe."
+          digest={error.digest}
+          ariaLabel="Application recovery"
+          className="min-h-svh"
+        />
       </body>
     </html>
   )

--- a/app/login/__tests__/page.test.tsx
+++ b/app/login/__tests__/page.test.tsx
@@ -1,0 +1,67 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const { socialMock } = vi.hoisted(() => ({
+  socialMock: vi.fn(),
+}))
+
+vi.mock("@/lib/auth-client", () => ({
+  signIn: {
+    social: socialMock,
+  },
+}))
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => new URLSearchParams(),
+}))
+
+vi.mock("../actions", () => ({
+  loginWithPAT: vi.fn(),
+}))
+
+import LoginPage from "../page"
+
+describe("GitHub OAuth login", () => {
+  beforeEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+  })
+
+  it("keeps the dashboard callback and surfaces a returned Better Auth error", async () => {
+    socialMock.mockResolvedValue({
+      data: null,
+      error: { message: "GitHub sign-in is not configured for this site." },
+    })
+
+    render(<LoginPage />)
+    fireEvent.click(screen.getByRole("button", { name: "Sign in with GitHub" }))
+
+    expect(await screen.findByText("GitHub sign-in is not configured for this site.")).toBeInTheDocument()
+    expect(socialMock).toHaveBeenCalledWith({
+      provider: "github",
+      callbackURL: "/dashboard",
+    })
+  })
+
+  it("surfaces a safe retry message when the auth request throws", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {})
+    socialMock.mockRejectedValue(new Error("network details must not be shown"))
+
+    render(<LoginPage />)
+    fireEvent.click(screen.getByRole("button", { name: "Sign in with GitHub" }))
+
+    expect(await screen.findByText("GitHub sign-in could not start. Please try again.")).toBeInTheDocument()
+    expect(screen.queryByText(/network details/i)).not.toBeInTheDocument()
+  })
+
+  it("prevents duplicate submissions while GitHub sign-in is pending", async () => {
+    socialMock.mockImplementation(() => new Promise(() => {}))
+
+    render(<LoginPage />)
+    fireEvent.click(screen.getByRole("button", { name: "Sign in with GitHub" }))
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "Connecting..." })).toBeDisabled())
+    fireEvent.click(screen.getByRole("button", { name: "Connecting..." }))
+    expect(socialMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -16,18 +16,25 @@ import { loginWithPAT } from "./actions"
 export default function LoginPage() {
   const [isLoading, setIsLoading] = useState(false)
   const [showToken, setShowToken] = useState(false)
+  const [authError, setAuthError] = useState<string | null>(null)
   const searchParams = useSearchParams()
   const error = searchParams.get("error")
 
   const handleLogin = async () => {
+    setAuthError(null)
     setIsLoading(true)
     try {
-      await signIn.social({
+      const result = await signIn.social({
         provider: "github",
         callbackURL: "/dashboard",
       })
+
+      if (result?.error) {
+        setAuthError(result.error.message || "GitHub sign-in could not start. Please try again.")
+      }
     } catch (err) {
       console.error("Error logging in:", err)
+      setAuthError("GitHub sign-in could not start. Please try again.")
     } finally {
       setIsLoading(false)
     }
@@ -43,12 +50,12 @@ export default function LoginPage() {
             <CardDescription>Sign in to manage your content</CardDescription>
           </CardHeader>
           <CardContent>
-            {error === "invalid_token" && (
+            {(error === "invalid_token" || authError) && (
               <Alert variant="destructive" className="mb-4 text-left">
                 <AlertCircle className="h-4 w-4" />
                 <AlertTitle>Authentication Failed</AlertTitle>
                 <AlertDescription>
-                  Your session has expired or your token is invalid. Please sign in again.
+                  {authError ?? "Your session has expired or your token is invalid. Please sign in again."}
                 </AlertDescription>
               </Alert>
             )}

--- a/components/__tests__/error-recovery.test.tsx
+++ b/components/__tests__/error-recovery.test.tsx
@@ -1,0 +1,50 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react"
+import { renderToStaticMarkup } from "react-dom/server"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("@sentry/nextjs", () => ({
+  captureException: vi.fn(),
+}))
+
+import DashboardError from "@/app/dashboard/error"
+import GlobalError from "@/app/global-error"
+import { ErrorRecovery } from "@/components/error-recovery"
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe("ErrorRecovery", () => {
+  it("explains that content is safe and offers retry and dashboard actions", () => {
+    const onRetry = vi.fn()
+
+    render(<ErrorRecovery onRetry={onRetry} digest="support-123" />)
+
+    expect(screen.getByRole("heading", { name: "We couldn't open this workspace" })).toBeInTheDocument()
+    expect(screen.getByText(/saved content and files in GitHub are safe/i)).toBeInTheDocument()
+    expect(screen.getByRole("link", { name: "Back to dashboard" })).toHaveAttribute("href", "/dashboard")
+    expect(screen.getByText("Reference support-123")).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }))
+    expect(onRetry).toHaveBeenCalledTimes(1)
+  })
+
+  it("keeps the dashboard boundary inside a section with recovery actions", () => {
+    const reset = vi.fn()
+
+    render(<DashboardError error={Object.assign(new Error("boom"), { digest: "dash-456" })} reset={reset} />)
+
+    expect(screen.getByRole("region", { name: "Workspace recovery" })).toBeInTheDocument()
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }))
+    expect(reset).toHaveBeenCalledTimes(1)
+  })
+
+  it("renders the branded recovery experience as the global fallback", () => {
+    const html = renderToStaticMarkup(<GlobalError error={new Error("boom")} reset={() => {}} />)
+
+    expect(html).toContain("RepoPress")
+    expect(html).toContain("We couldn&#x27;t open RepoPress")
+    expect(html).toContain("Try again")
+  })
+})

--- a/components/error-recovery.tsx
+++ b/components/error-recovery.tsx
@@ -30,9 +30,7 @@ export function ErrorRecovery({
       <div className="w-full max-w-xl border-y border-border py-10 sm:rounded-lg sm:border sm:px-10">
         <div className="flex items-center gap-3">
           <BrandMark tile className="size-10" />
-          <p className="font-mono text-[0.65rem] uppercase tracking-[0.22em] text-muted-foreground">
-            Recovery
-          </p>
+          <p className="font-mono text-[0.65rem] uppercase tracking-[0.22em] text-muted-foreground">Recovery</p>
         </div>
 
         <div className="mt-8 space-y-3">
@@ -54,9 +52,7 @@ export function ErrorRecovery({
         </div>
 
         {digest ? (
-          <p className="mt-8 border-t border-border pt-4 font-mono text-xs text-muted-foreground">
-            Reference {digest}
-          </p>
+          <p className="mt-8 border-t border-border pt-4 font-mono text-xs text-muted-foreground">Reference {digest}</p>
         ) : null}
       </div>
     </section>

--- a/components/error-recovery.tsx
+++ b/components/error-recovery.tsx
@@ -1,0 +1,64 @@
+"use client"
+
+import { ArrowLeft, RefreshCw } from "lucide-react"
+import { BrandMark } from "@/components/brand/logo"
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+
+interface ErrorRecoveryProps {
+  onRetry: () => void
+  title?: string
+  description?: string
+  digest?: string
+  className?: string
+  ariaLabel?: string
+}
+
+export function ErrorRecovery({
+  onRetry,
+  title = "We couldn't open this workspace",
+  description = "Something interrupted this view. Your saved content and files in GitHub are safe.",
+  digest,
+  className,
+  ariaLabel = "Workspace recovery",
+}: ErrorRecoveryProps) {
+  return (
+    <section
+      aria-label={ariaLabel}
+      className={cn("flex min-h-[60vh] w-full items-center justify-center px-4 py-12 sm:px-6", className)}
+    >
+      <div className="w-full max-w-xl border-y border-border py-10 sm:rounded-lg sm:border sm:px-10">
+        <div className="flex items-center gap-3">
+          <BrandMark tile className="size-10" />
+          <p className="font-mono text-[0.65rem] uppercase tracking-[0.22em] text-muted-foreground">
+            Recovery
+          </p>
+        </div>
+
+        <div className="mt-8 space-y-3">
+          <h1 className="rp-display text-4xl tracking-[-0.025em] text-foreground sm:text-5xl">{title}</h1>
+          <p className="max-w-lg text-sm leading-6 text-muted-foreground sm:text-base">{description}</p>
+        </div>
+
+        <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+          <Button type="button" onClick={onRetry}>
+            <RefreshCw />
+            Try again
+          </Button>
+          <Button variant="outline" asChild>
+            <a href="/dashboard">
+              <ArrowLeft />
+              Back to dashboard
+            </a>
+          </Button>
+        </div>
+
+        {digest ? (
+          <p className="mt-8 border-t border-border pt-4 font-mono text-xs text-muted-foreground">
+            Reference {digest}
+          </p>
+        ) : null}
+      </div>
+    </section>
+  )
+}

--- a/docs/plans/2026-08-02-production-hardening-design.md
+++ b/docs/plans/2026-08-02-production-hardening-design.md
@@ -32,9 +32,9 @@ Copy the existing production Convex `REPOPRESS_CAPABILITY_SECRET` into productio
 
 ### Dedicated Compatible preview origin
 
-Add a deployment-role gate controlled by `REPOPRESS_DEPLOYMENT_ROLE=sandbox`. In sandbox mode, only `/preview/sandbox` and the static assets required to render it are reachable; application, dashboard, auth, and mutation routes return 404. Normal Studio deployments are unchanged.
+Add a deployment-role gate controlled by `REPOPRESS_DEPLOYMENT_ROLE=sandbox`. In sandbox mode, only `GET` and `HEAD` requests for `/preview/sandbox`, immutable Next.js bundles, and an exact allowlist of public assets required to render it are reachable; application, dashboard, auth, mutation, and dynamic extension-suffixed routes return 404. Normal Studio deployments are unchanged.
 
-Create a dedicated public Vercel sandbox project from the same reviewed commit. Generate one P-256 key pair: the private JWK is server-only in the Studio production environment, while the matching public JWK is browser-readable in both Studio and sandbox builds. Point `NEXT_PUBLIC_PREVIEW_ORIGIN` at the dedicated sandbox production origin. The sandbox remains public at the network edge because repository code is admitted only through RepoPress's signed approval protocol and executes inside the opaque iframe containment boundary.
+Create a dedicated public Vercel sandbox project from the same reviewed commit. Generate one P-256 key pair: the private JWK is server-only in the Studio production environment, while the matching public JWK is browser-readable in both Studio and sandbox builds. The sandbox also receives the public Convex URL and site URL because the shared application build requires them; the role gate prevents those values from exposing application or API routes at runtime. Point `NEXT_PUBLIC_PREVIEW_ORIGIN` at the dedicated sandbox production origin. The sandbox remains public at the network edge because repository code is admitted only through RepoPress's signed approval protocol and executes inside the opaque iframe containment boundary.
 
 ### Data flow
 

--- a/docs/plans/2026-08-02-production-hardening-design.md
+++ b/docs/plans/2026-08-02-production-hardening-design.md
@@ -1,0 +1,58 @@
+# Production Hardening Design
+
+## Goal
+
+Make the merged MDX component ecosystem usable in production by fixing GitHub OAuth, replacing the bare crash screen with actionable recovery UI, and deploying Compatible preview on a separately isolated origin.
+
+## Confirmed failures
+
+- Production Convex has no `SITE_URL`, so Better Auth rejects `POST /api/auth/sign-in/social` with HTTP 403.
+- The login client catches thrown exceptions but ignores Better Auth's returned `{ error }`, so OAuth failures are silent.
+- Production Vercel has no `REPOPRESS_CAPABILITY_SECRET`, so repository hubs fail closed while minting project capabilities.
+- `app/global-error.tsx` is an unstyled last-resort boundary, and there is no dashboard route boundary to preserve useful navigation and recovery actions.
+- A Vercel-protected preview deployment cannot be embedded as a third-party iframe. Compatible preview requires a distinct, publicly reachable sandbox origin.
+
+## Architecture
+
+### Error recovery UI
+
+Add a reusable branded error-state component using the Editorial design system. A dashboard-level `error.tsx` keeps failures inside the authenticated product shell and offers `Try again` and `Back to dashboard`. The root `global-error.tsx` uses the same visual language as a standalone last resort without depending on application providers that may have failed.
+
+Messages remain calm and specific: the workspace could not open, saved GitHub content is unaffected, and retry/navigation are available. Unexpected error details remain in telemetry; only the opaque digest may be shown for support.
+
+### GitHub OAuth
+
+Treat `signIn.social` as a result-bearing API. A returned Better Auth error becomes a visible destructive alert, thrown/network failures use a generic retry message, and successful results retain the requested safe in-app callback. Loading state always settles and duplicate submission remains disabled.
+
+Production Convex receives `SITE_URL=https://repo-press-itsyogesh.vercel.app`. The GitHub OAuth callback remains routed through `/api/auth/callback/github` on the application origin so the application domain receives the session cookies.
+
+### Capability configuration
+
+Copy the existing production Convex `REPOPRESS_CAPABILITY_SECRET` into production Vercel without displaying or persisting its value outside the managed environment. This remains a production setting because repository, media, and publish capabilities depend on it.
+
+### Dedicated Compatible preview origin
+
+Add a deployment-role gate controlled by `REPOPRESS_DEPLOYMENT_ROLE=sandbox`. In sandbox mode, only `/preview/sandbox` and the static assets required to render it are reachable; application, dashboard, auth, and mutation routes return 404. Normal Studio deployments are unchanged.
+
+Create a dedicated public Vercel sandbox project from the same reviewed commit. Generate one P-256 key pair: the private JWK is server-only in the Studio production environment, while the matching public JWK is browser-readable in both Studio and sandbox builds. Point `NEXT_PUBLIC_PREVIEW_ORIGIN` at the dedicated sandbox production origin. The sandbox remains public at the network edge because repository code is admitted only through RepoPress's signed approval protocol and executes inside the opaque iframe containment boundary.
+
+### Data flow
+
+1. User authenticates with GitHub through the production app and Convex Better Auth.
+2. Studio loads a repository document and requests a compatible artifact from the production server.
+3. The production server resolves the pinned product adapter and signs the exact artifact with the private P-256 key.
+4. The browser sends the artifact and signature to the opaque iframe hosted on the dedicated sandbox origin.
+5. The sandbox verifies the public-key signature and existing protocol constraints before executing the approved adapter.
+
+## Testing
+
+- Unit/component tests for returned OAuth errors, thrown OAuth failures, callback retention, loading state, and successful redirection behavior.
+- Component tests for branded dashboard and global recovery states, including accessible headings and actions.
+- Proxy/route-gate tests proving sandbox mode allows only the preview document and required Next.js assets while rejecting dashboard, auth, and API routes.
+- Existing capability, signing, sandbox-containment, and Studio suites remain green.
+- Full lint, typecheck, test, build, and `git diff --check` verification.
+- Production browser E2E: GitHub OAuth, PAT fallback, Merry Magic Mail setup, target MDX document, five product components, Compatible preview iframe, error recovery, and 375 px responsive controls.
+
+## Rollback
+
+The code change is isolated in one PR. Deployment rollback consists of restoring the previous Studio deployment, removing the sandbox project, removing the preview signing variables and origin from Studio, and retaining the production capability secret and `SITE_URL` because they are required independently of Compatible preview.

--- a/docs/plans/2026-08-02-production-hardening.md
+++ b/docs/plans/2026-08-02-production-hardening.md
@@ -175,9 +175,13 @@ Create a dedicated Vercel project from the reviewed branch with:
 
 - `REPOPRESS_DEPLOYMENT_ROLE=sandbox`;
 - `NEXT_PUBLIC_APP_URL=https://repo-press-itsyogesh.vercel.app` for CSP `frame-ancestors`;
+- the public production `NEXT_PUBLIC_CONVEX_URL` and `NEXT_PUBLIC_CONVEX_SITE_URL` required by the shared build;
 - the matching `NEXT_PUBLIC_PREVIEW_APPROVAL_PUBLIC_KEY_JWK`.
 
-Keep the sandbox production deployment public; do not add Studio auth or the private key.
+Keep the sandbox production deployment public; do not add Studio auth,
+`CONVEX_DEPLOYMENT`, the capability secret, or the private key. The deployment
+gate must still reject all runtime application/API routes and all non-GET/HEAD
+requests.
 
 **Step 5: Push, open PR, review, and merge**
 

--- a/docs/plans/2026-08-02-production-hardening.md
+++ b/docs/plans/2026-08-02-production-hardening.md
@@ -1,0 +1,217 @@
+# Production Hardening Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make production OAuth, repository setup, error recovery, and isolated Compatible preview work end to end.
+
+**Architecture:** Keep Better Auth inside Convex and fix its production origin configuration rather than changing auth ownership. Add a shared Editorial recovery component plus route-level boundaries, and restrict a dedicated public sandbox deployment at the Next.js proxy using an explicit deployment role. Production Studio signs exact artifacts; the public sandbox verifies and executes only approved artifacts inside the existing opaque iframe.
+
+**Tech Stack:** Next.js 16 App Router and proxy, React 19, Better Auth in Convex, Vitest and Testing Library, Vercel CLI, Chrome E2E.
+
+---
+
+### Task 1: Surface GitHub OAuth failures
+
+**Files:**
+- Create: `app/login/__tests__/page.test.tsx`
+- Modify: `app/login/page.tsx`
+
+**Step 1: Write the failing tests**
+
+Mock `signIn.social` and prove that the login page:
+
+- sends the safe `/dashboard` callback;
+- renders a returned Better Auth error message;
+- renders a generic message for a thrown/network failure;
+- disables duplicate submission while the request is pending.
+
+**Step 2: Verify RED**
+
+Run: `npx vitest run app/login/__tests__/page.test.tsx`
+
+Expected: failures because the current handler ignores returned errors and has no local alert state.
+
+**Step 3: Implement the minimal behavior**
+
+Add local `authError` state, clear it before a new attempt, inspect the result returned from `signIn.social`, and surface a safe message in the existing destructive `Alert`. Preserve the loading state and callback.
+
+**Step 4: Verify GREEN**
+
+Run: `npx vitest run app/login/__tests__/page.test.tsx`
+
+Expected: all login component tests pass.
+
+**Step 5: Commit**
+
+Commit message: `fix(auth): surface GitHub sign-in failures`
+
+### Task 2: Add branded recovery boundaries
+
+**Files:**
+- Create: `components/error-recovery.tsx`
+- Create: `components/__tests__/error-recovery.test.tsx`
+- Create: `app/dashboard/error.tsx`
+- Modify: `app/global-error.tsx`
+
+**Step 1: Write the failing tests**
+
+Render the recovery component and route boundaries. Assert an accessible heading, calm safety copy, retry action, dashboard navigation, and optional support digest. Assert that retry invokes `reset` exactly once.
+
+**Step 2: Verify RED**
+
+Run: `npx vitest run components/__tests__/error-recovery.test.tsx`
+
+Expected: module-not-found failure for the new component/boundary.
+
+**Step 3: Implement the Editorial UI**
+
+Build a flat, bordered, whitespace-forward recovery state using `BrandMark`, `Button`, Lucide's `RefreshCw` and `ArrowLeft`, token colors, serif display text, and no shadows or gradients. The dashboard boundary renders inside the existing shell; the global boundary supplies its own `html` and `body`.
+
+**Step 4: Verify GREEN**
+
+Run: `npx vitest run components/__tests__/error-recovery.test.tsx`
+
+Expected: all recovery UI tests pass.
+
+**Step 5: Commit**
+
+Commit message: `fix(ui): add actionable error recovery`
+
+### Task 3: Enforce a sandbox-only deployment role
+
+**Files:**
+- Create: `lib/deployment-role.ts`
+- Create: `lib/__tests__/deployment-role.test.ts`
+- Modify: `proxy.ts`
+- Modify: `lib/__tests__/proxy.test.ts`
+- Modify: `README.md`
+- Modify: `docs/production-deployment-guide.md`
+
+**Step 1: Write the failing policy and proxy tests**
+
+Prove that normal deployments preserve all current routing, while `REPOPRESS_DEPLOYMENT_ROLE=sandbox` allows `/preview/sandbox` and required static assets but returns 404 for `/`, `/login`, `/dashboard`, `/api/auth/*`, and mutation APIs. Assert the broader static matcher required to apply the gate.
+
+**Step 2: Verify RED**
+
+Run: `npx vitest run lib/__tests__/deployment-role.test.ts lib/__tests__/proxy.test.ts`
+
+Expected: failures because no deployment-role policy exists and the current matcher covers only root/login/dashboard.
+
+**Step 3: Implement the minimal gate**
+
+Add a pure allow/deny policy. Apply it before auth redirects in `proxy.ts`; return a plain 404 response in sandbox mode for all non-sandbox application routes. Use a negative-lookahead matcher that excludes immutable Next/static and public asset extensions while covering all application paths.
+
+**Step 4: Update deployment documentation**
+
+Document `REPOPRESS_DEPLOYMENT_ROLE`, the separate sandbox project, its public network requirement, Studio/sandbox key placement, and `SITE_URL` as the application origin used by Better Auth.
+
+**Step 5: Verify GREEN**
+
+Run: `npx vitest run lib/__tests__/deployment-role.test.ts lib/__tests__/proxy.test.ts components/__tests__/root-chrome.test.tsx components/preview-sandbox/__tests__/SandboxRuntime.test.tsx`
+
+Expected: all role, proxy, root-chrome, and sandbox tests pass.
+
+**Step 6: Commit**
+
+Commit message: `feat(preview): isolate sandbox deployments`
+
+### Task 4: Verify the code slice
+
+**Files:**
+- Review all files changed by Tasks 1-3.
+
+**Step 1: Run focused suites**
+
+Run all new and directly affected tests and confirm they pass without unexpected console output.
+
+**Step 2: Run static verification**
+
+Run:
+
+- `./node_modules/.bin/tsc --noEmit`
+- `npm run lint`
+- `git diff --check`
+
+Expected: clean typecheck/diff and no new Biome warnings.
+
+**Step 3: Run full verification**
+
+Run:
+
+- `npm test`
+- `npm run build`
+
+Expected: all tests and the production build pass.
+
+**Step 4: Commit any test-only cleanup**
+
+Commit message, only if needed: `test: close production hardening regressions`
+
+### Task 5: Configure and deploy production safely
+
+**Files:**
+- No secret files. Use managed Convex and Vercel environment stores only.
+
+**Step 1: Configure Convex auth origin**
+
+Set production Convex `SITE_URL` to `https://repo-press-itsyogesh.vercel.app`. Retain the existing production capability secret.
+
+**Step 2: Generate preview signing material**
+
+Generate a P-256 key pair in memory. Never print or write the private JWK.
+
+**Step 3: Configure production Studio**
+
+Set production Vercel:
+
+- `REPOPRESS_CAPABILITY_SECRET` from production Convex;
+- `PREVIEW_APPROVAL_PRIVATE_KEY_JWK` to the private JWK;
+- `NEXT_PUBLIC_PREVIEW_APPROVAL_PUBLIC_KEY_JWK` to the public JWK;
+- `NEXT_PUBLIC_PREVIEW_ORIGIN` to the dedicated sandbox origin.
+
+**Step 4: Create/configure the sandbox project**
+
+Create a dedicated Vercel project from the reviewed branch with:
+
+- `REPOPRESS_DEPLOYMENT_ROLE=sandbox`;
+- `NEXT_PUBLIC_APP_URL=https://repo-press-itsyogesh.vercel.app` for CSP `frame-ancestors`;
+- the matching `NEXT_PUBLIC_PREVIEW_APPROVAL_PUBLIC_KEY_JWK`.
+
+Keep the sandbox production deployment public; do not add Studio auth or the private key.
+
+**Step 5: Push, open PR, review, and merge**
+
+Push `fix/production-hardening`, open a PR, confirm CI, perform a differential review, and merge only when clean.
+
+**Step 6: Redeploy both roles from the merged commit**
+
+Deploy the sandbox project and main Studio production with the finalized configuration. Confirm both deployment SHAs match the reviewed source.
+
+### Task 6: Production browser E2E
+
+**Files:**
+- No repository changes unless a reproducible defect is found; any defect starts a fresh RED/GREEN cycle.
+
+**Step 1: Test GitHub OAuth**
+
+Use Chrome to sign out of PAT state, start GitHub OAuth, confirm the redirect reaches GitHub, returns through `/api/auth/callback/github`, sets the app session, and loads the dashboard. Verify a forced returned-error fixture locally renders the new alert.
+
+**Step 2: Test repository connection**
+
+Open `itsyogesh/merry-magic-mail`, create or sync its production project, and confirm no capability/configuration error appears.
+
+**Step 3: Test Studio and MDX components**
+
+Open `apps/web/app/(main)/blog/santa-letter-template-free/page.mdx`. Confirm CoverImage, InfoBox, LetterPaper, Checklist, and CTABox are discovered and available in the insert palette.
+
+**Step 4: Test Compatible iframe**
+
+Switch to Compatible fidelity. Confirm the iframe document loads from the dedicated sandbox origin, the signed adapter renders, there are no CSP/protection failures, and no host-realm repository code executes.
+
+**Step 5: Test recovery and responsive UI**
+
+Exercise a recoverable repository failure and validate the branded boundary. At 375×812, confirm Save and More remain visible and compact project/theme controls are reachable.
+
+**Step 6: Cleanup temporary E2E infrastructure**
+
+After the permanent production Studio and dedicated sandbox pass, delete the obsolete temporary deployments/aliases and revoke the temporary Vercel bypass. Do not remove permanent production configuration.

--- a/docs/plans/production_launch_redesign_plan.md
+++ b/docs/plans/production_launch_redesign_plan.md
@@ -559,8 +559,8 @@ Add footer links from `components/landing/footer.tsx`.
   - `GITHUB_CLIENT_ID` - production GitHub OAuth App
   - `GITHUB_CLIENT_SECRET` - production secret
   - `BETTER_AUTH_SECRET` - generate NEW random secret for prod (do NOT reuse dev)
-  - `SITE_URL` - production Convex site URL (e.g., `https://repopress.convex.site`)
-- Update GitHub OAuth App: add production callback URL `https://<prod>.convex.site/api/auth/callback/github`
+  - `SITE_URL` - public production application origin (e.g., `https://repopress.example`)
+- Update GitHub OAuth App: add production callback URL `https://<app-origin>/api/auth/callback/github`
 - Run `npx convex deploy --prod` to push schema and functions
 
 **Acceptance**: OAuth login works on production domain without affecting dev environment.

--- a/docs/production-deployment-guide.md
+++ b/docs/production-deployment-guide.md
@@ -56,9 +56,11 @@ Step-by-step instructions for deploying RepoPress to production. This guide cove
 2. **Create a new OAuth App** (separate from dev):
    - **Application name**: `RepoPress` (or `RepoPress Production`)
    - **Homepage URL**: `https://your-domain.com`
-   - **Authorization callback URL**: `https://<your-project>.convex.site/api/auth/callback/github`
+   - **Authorization callback URL**: `https://your-domain.com/api/auth/callback/github`
 
-   > ⚠️ The callback URL MUST point to your **Convex site URL**, not your Vercel domain. Better Auth runs inside Convex.
+   > The callback URL must use the public RepoPress application origin. The
+   > Next.js auth route proxies the callback to Better Auth in Convex and lets
+   > the application origin receive the session cookies.
 
 3. **Copy the Client ID and Client Secret** - you already set these in Step 1.
 
@@ -98,12 +100,17 @@ protection disabled and these production variables:
 |----------|-------|
 | `REPOPRESS_DEPLOYMENT_ROLE` | `sandbox` |
 | `NEXT_PUBLIC_APP_URL` | Public Studio origin, used by the sandbox CSP `frame-ancestors` rule |
+| `NEXT_PUBLIC_CONVEX_URL` | Same public Convex deployment URL used by Studio; required at build time |
+| `NEXT_PUBLIC_CONVEX_SITE_URL` | Same public Convex site URL used by Studio; required at build time |
 | `NEXT_PUBLIC_PREVIEW_APPROVAL_PUBLIC_KEY_JWK` | Public half of the Studio signing key pair |
 
-The sandbox role serves only `/preview/sandbox` and immutable assets. It must
-not receive the private signing JWK, GitHub credentials, auth secrets, or the
-RepoPress capability secret. The origin is public at the network edge because
-the signed approval protocol and opaque iframe are the execution boundary.
+The Convex URLs are public build configuration, not credentials. The sandbox
+role still rejects runtime application and API access: it serves only `GET` and
+`HEAD` requests for `/preview/sandbox`, immutable Next.js bundles, and the exact
+public assets needed by that page. It must not receive the private signing JWK,
+GitHub credentials, auth secrets, `CONVEX_DEPLOYMENT`, or the RepoPress
+capability secret. The origin is public at the network edge because the signed
+approval protocol and opaque iframe are the execution boundary.
 
 ---
 
@@ -200,7 +207,7 @@ Run Lighthouse on `/` targeting:
 | Symptom | Cause | Fix |
 |---------|-------|-----|
 | "ConvexReactClient not initialized" | Missing `NEXT_PUBLIC_CONVEX_URL` | Set it in Vercel env vars and redeploy |
-| OAuth callback fails | Wrong callback URL in GitHub OAuth App | Must be `https://<project>.convex.site/api/auth/callback/github` |
+| OAuth callback fails | Wrong callback URL in GitHub OAuth App | Must be `https://<app-origin>/api/auth/callback/github` |
 | "ctx is not a mutation context" | Auth.ts modified incorrectly | Reset `convex/auth.ts` from git |
 | 401 on API routes | Missing/expired GitHub token | Re-login via OAuth |
 | OG image not showing | `NEXT_PUBLIC_APP_URL` not set | Set it and redeploy for correct `metadataBase` |

--- a/docs/production-deployment-guide.md
+++ b/docs/production-deployment-guide.md
@@ -35,7 +35,7 @@ Step-by-step instructions for deploying RepoPress to production. This guide cove
    | `GITHUB_CLIENT_SECRET` | Your GitHub OAuth App client secret | - |
    | `BETTER_AUTH_SECRET` | A new random 32+ character string | **Do NOT reuse the dev secret** |
    | `REPOPRESS_CAPABILITY_SECRET` | A new random 32+ character string | Also configure this exact value in Vercel; do not reuse `BETTER_AUTH_SECRET` |
-   | `SITE_URL` | `https://<your-project>.convex.site` | Your Convex production site URL |
+   | `SITE_URL` | `https://your-domain.com` | Public RepoPress application origin; Better Auth callbacks return through this origin |
 
    Generate independent secrets for Better Auth and RepoPress capabilities:
    ```bash
@@ -77,6 +77,9 @@ Step-by-step instructions for deploying RepoPress to production. This guide cove
    | `CONVEX_DEPLOYMENT` | `prod:<your-project>` | Production |
    | `NEXT_PUBLIC_APP_URL` | `https://your-domain.com` | Production |
    | `REPOPRESS_CAPABILITY_SECRET` | Same value configured in the production Convex deployment | Production |
+   | `PREVIEW_APPROVAL_PRIVATE_KEY_JWK` | Server-only private JWK from a generated EC P-256 key pair | Production |
+   | `NEXT_PUBLIC_PREVIEW_APPROVAL_PUBLIC_KEY_JWK` | Public JWK matching the private signing key | Production |
+   | `NEXT_PUBLIC_PREVIEW_ORIGIN` | HTTPS origin of the dedicated public sandbox project | Production |
    | `NEXT_PUBLIC_SENTRY_DSN` | Your Sentry DSN (optional) | Production |
    | `SENTRY_ORG` | Your Sentry org slug (optional) | Production |
    | `SENTRY_PROJECT` | Your Sentry project slug (optional) | Production |
@@ -85,6 +88,22 @@ Step-by-step instructions for deploying RepoPress to production. This guide cove
 3. **Trigger a deploy** (push to main or manual deploy from Vercel dashboard).
 
 4. **Verify**: Visit `https://your-domain.com` - the landing page should load.
+
+### Dedicated Compatible preview project
+
+Deploy the same reviewed commit as a separate Vercel project with deployment
+protection disabled and these production variables:
+
+| Variable | Value |
+|----------|-------|
+| `REPOPRESS_DEPLOYMENT_ROLE` | `sandbox` |
+| `NEXT_PUBLIC_APP_URL` | Public Studio origin, used by the sandbox CSP `frame-ancestors` rule |
+| `NEXT_PUBLIC_PREVIEW_APPROVAL_PUBLIC_KEY_JWK` | Public half of the Studio signing key pair |
+
+The sandbox role serves only `/preview/sandbox` and immutable assets. It must
+not receive the private signing JWK, GitHub credentials, auth secrets, or the
+RepoPress capability secret. The origin is public at the network edge because
+the signed approval protocol and opaque iframe are the execution boundary.
 
 ---
 

--- a/docs/rollback-runbook.md
+++ b/docs/rollback-runbook.md
@@ -75,7 +75,7 @@ Convex provides automatic backups:
 
 1. Go to [GitHub Developer Settings](https://github.com/settings/developers)
 2. Select your OAuth App
-3. Update "Authorization callback URL" to: `https://<prod-convex>.convex.site/api/auth/callback/github`
+3. Update "Authorization callback URL" to: `https://<app-origin>/api/auth/callback/github`
 4. Verify: attempt OAuth login flow
 
 ### Session tokens invalid

--- a/lib/__tests__/deployment-role.test.ts
+++ b/lib/__tests__/deployment-role.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest"
-import { canServeDeploymentPath } from "@/lib/deployment-role"
+import { canServeDeploymentRequest } from "@/lib/deployment-role"
 
-describe("deployment role path policy", () => {
+describe("deployment role request policy", () => {
   it.each([
     "/",
     "/login",
@@ -10,8 +10,11 @@ describe("deployment role path policy", () => {
     "/api/auth/get-session",
     "/api/github/tree",
     "/_next/image",
+    "/dashboard/acme/repo/blob/private.png",
+    "/blog/diagram.svg",
+    "/secret.png",
   ])("rejects %s from a sandbox-only deployment", (pathname) => {
-    expect(canServeDeploymentPath(pathname, "sandbox")).toBe(false)
+    expect(canServeDeploymentRequest(pathname, "GET", "sandbox")).toBe(false)
   })
 
   it.each([
@@ -20,17 +23,35 @@ describe("deployment role path policy", () => {
     "/esbuild.wasm",
     "/icon.svg",
     "/icon-light-32x32.png",
+    "/icon-dark-32x32.png",
+    "/apple-icon.png",
   ])("allows the sandbox document or required immutable asset %s", (pathname) => {
-    expect(canServeDeploymentPath(pathname, "sandbox")).toBe(true)
+    expect(canServeDeploymentRequest(pathname, "GET", "sandbox")).toBe(true)
+    expect(canServeDeploymentRequest(pathname, "HEAD", "sandbox")).toBe(true)
+  })
+
+  it.each([
+    "POST",
+    "PUT",
+    "PATCH",
+    "DELETE",
+    "OPTIONS",
+  ])("rejects %s requests even for the sandbox document", (method) => {
+    expect(canServeDeploymentRequest("/preview/sandbox", method, "sandbox")).toBe(false)
+  })
+
+  it("does not infer public access from an allowed asset's extension", () => {
+    expect(canServeDeploymentRequest("/nested/icon.svg", "GET", "sandbox")).toBe(false)
+    expect(canServeDeploymentRequest("/esbuild.wasm/extra", "GET", "sandbox")).toBe(false)
   })
 
   it("does not allow a path that merely shares the sandbox prefix", () => {
-    expect(canServeDeploymentPath("/preview/sandbox/admin", "sandbox")).toBe(false)
-    expect(canServeDeploymentPath("/preview/sandboxx", "sandbox")).toBe(false)
+    expect(canServeDeploymentRequest("/preview/sandbox/admin", "GET", "sandbox")).toBe(false)
+    expect(canServeDeploymentRequest("/preview/sandboxx", "GET", "sandbox")).toBe(false)
   })
 
   it("does not constrain a normal Studio deployment", () => {
-    expect(canServeDeploymentPath("/dashboard/acme/docs", undefined)).toBe(true)
-    expect(canServeDeploymentPath("/api/github/publish-ops", "studio")).toBe(true)
+    expect(canServeDeploymentRequest("/dashboard/acme/docs", "GET", undefined)).toBe(true)
+    expect(canServeDeploymentRequest("/api/github/publish-ops", "POST", "studio")).toBe(true)
   })
 })

--- a/lib/__tests__/deployment-role.test.ts
+++ b/lib/__tests__/deployment-role.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest"
+import { canServeDeploymentPath } from "@/lib/deployment-role"
+
+describe("deployment role path policy", () => {
+  it.each(["/", "/login", "/dashboard", "/dashboard/acme/docs", "/api/auth/get-session", "/api/github/tree"])(
+    "rejects %s from a sandbox-only deployment",
+    (pathname) => {
+      expect(canServeDeploymentPath(pathname, "sandbox")).toBe(false)
+    },
+  )
+
+  it.each([
+    "/preview/sandbox",
+    "/_next/static/chunks/app.js",
+    "/_next/image",
+    "/esbuild.wasm",
+    "/icon.svg",
+    "/icon-light-32x32.png",
+  ])("allows the sandbox document or required immutable asset %s", (pathname) => {
+    expect(canServeDeploymentPath(pathname, "sandbox")).toBe(true)
+  })
+
+  it("does not allow a path that merely shares the sandbox prefix", () => {
+    expect(canServeDeploymentPath("/preview/sandbox/admin", "sandbox")).toBe(false)
+    expect(canServeDeploymentPath("/preview/sandboxx", "sandbox")).toBe(false)
+  })
+
+  it("does not constrain a normal Studio deployment", () => {
+    expect(canServeDeploymentPath("/dashboard/acme/docs", undefined)).toBe(true)
+    expect(canServeDeploymentPath("/api/github/publish-ops", "studio")).toBe(true)
+  })
+})

--- a/lib/__tests__/deployment-role.test.ts
+++ b/lib/__tests__/deployment-role.test.ts
@@ -2,12 +2,16 @@ import { describe, expect, it } from "vitest"
 import { canServeDeploymentPath } from "@/lib/deployment-role"
 
 describe("deployment role path policy", () => {
-  it.each(["/", "/login", "/dashboard", "/dashboard/acme/docs", "/api/auth/get-session", "/api/github/tree"])(
-    "rejects %s from a sandbox-only deployment",
-    (pathname) => {
-      expect(canServeDeploymentPath(pathname, "sandbox")).toBe(false)
-    },
-  )
+  it.each([
+    "/",
+    "/login",
+    "/dashboard",
+    "/dashboard/acme/docs",
+    "/api/auth/get-session",
+    "/api/github/tree",
+  ])("rejects %s from a sandbox-only deployment", (pathname) => {
+    expect(canServeDeploymentPath(pathname, "sandbox")).toBe(false)
+  })
 
   it.each([
     "/preview/sandbox",

--- a/lib/__tests__/deployment-role.test.ts
+++ b/lib/__tests__/deployment-role.test.ts
@@ -9,6 +9,7 @@ describe("deployment role path policy", () => {
     "/dashboard/acme/docs",
     "/api/auth/get-session",
     "/api/github/tree",
+    "/_next/image",
   ])("rejects %s from a sandbox-only deployment", (pathname) => {
     expect(canServeDeploymentPath(pathname, "sandbox")).toBe(false)
   })
@@ -16,7 +17,6 @@ describe("deployment role path policy", () => {
   it.each([
     "/preview/sandbox",
     "/_next/static/chunks/app.js",
-    "/_next/image",
     "/esbuild.wasm",
     "/icon.svg",
     "/icon-light-32x32.png",

--- a/lib/__tests__/proxy.test.ts
+++ b/lib/__tests__/proxy.test.ts
@@ -1,6 +1,10 @@
 import { NextRequest } from "next/server"
-import { describe, expect, it } from "vitest"
+import { afterEach, describe, expect, it } from "vitest"
 import { config, proxy } from "@/proxy"
+
+afterEach(() => {
+  delete process.env.REPOPRESS_DEPLOYMENT_ROLE
+})
 
 describe("proxy.ts", () => {
   it("redirects unauthenticated dashboard requests to /login", () => {
@@ -59,9 +63,27 @@ describe("proxy.ts", () => {
     expect(response.headers.get("location")).toBe("https://repo-press.dev/dashboard")
   })
 
-  it("exports a static matcher config for login and dashboard routes", () => {
+  it("returns 404 for application and API routes in a sandbox-only deployment", () => {
+    process.env.REPOPRESS_DEPLOYMENT_ROLE = "sandbox"
+
+    for (const pathname of ["/", "/login", "/dashboard/acme/docs", "/api/auth/get-session", "/api/github/tree"]) {
+      const response = proxy(new NextRequest(`https://preview.repo-press.dev${pathname}`))
+
+      expect(response.status, pathname).toBe(404)
+      expect(response.headers.get("location"), pathname).toBeNull()
+    }
+  })
+
+  it("allows the exact sandbox route through without authentication", () => {
+    process.env.REPOPRESS_DEPLOYMENT_ROLE = "sandbox"
+    const response = proxy(new NextRequest("https://preview.repo-press.dev/preview/sandbox"))
+
+    expect(response.headers.get("x-middleware-next")).toBe("1")
+  })
+
+  it("exports a static matcher that covers application and API routes while excluding immutable assets", () => {
     expect(config).toEqual({
-      matcher: ["/", "/login/:path*", "/dashboard/:path*"],
+      matcher: ["/((?!_next/static|_next/image|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico|woff2?|ttf|wasm)$).*)"],
     })
   })
 })

--- a/lib/__tests__/proxy.test.ts
+++ b/lib/__tests__/proxy.test.ts
@@ -66,7 +66,14 @@ describe("proxy.ts", () => {
   it("returns 404 for application and API routes in a sandbox-only deployment", () => {
     process.env.REPOPRESS_DEPLOYMENT_ROLE = "sandbox"
 
-    for (const pathname of ["/", "/login", "/dashboard/acme/docs", "/api/auth/get-session", "/api/github/tree"]) {
+    for (const pathname of [
+      "/",
+      "/login",
+      "/dashboard/acme/docs",
+      "/api/auth/get-session",
+      "/api/github/tree",
+      "/_next/image",
+    ]) {
       const response = proxy(new NextRequest(`https://preview.repo-press.dev${pathname}`))
 
       expect(response.status, pathname).toBe(404)
@@ -83,7 +90,7 @@ describe("proxy.ts", () => {
 
   it("exports a static matcher that covers application and API routes while excluding immutable assets", () => {
     expect(config).toEqual({
-      matcher: ["/((?!_next/static|_next/image|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico|woff2?|ttf|wasm)$).*)"],
+      matcher: ["/((?!_next/static|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico|woff2?|ttf|wasm)$).*)"],
     })
   })
 })

--- a/lib/__tests__/proxy.test.ts
+++ b/lib/__tests__/proxy.test.ts
@@ -73,6 +73,8 @@ describe("proxy.ts", () => {
       "/api/auth/get-session",
       "/api/github/tree",
       "/_next/image",
+      "/dashboard/acme/repo/blob/private.png",
+      "/blog/diagram.svg",
     ]) {
       const response = proxy(new NextRequest(`https://preview.repo-press.dev${pathname}`))
 
@@ -88,9 +90,34 @@ describe("proxy.ts", () => {
     expect(response.headers.get("x-middleware-next")).toBe("1")
   })
 
+  it.each([
+    "POST",
+    "PUT",
+    "PATCH",
+    "DELETE",
+    "OPTIONS",
+  ])("returns 404 for %s requests to the sandbox document", (method) => {
+    process.env.REPOPRESS_DEPLOYMENT_ROLE = "sandbox"
+    const response = proxy(
+      new NextRequest("https://preview.repo-press.dev/preview/sandbox", {
+        method,
+      }),
+    )
+
+    expect(response.status).toBe(404)
+    expect(response.headers.get("cache-control")).toBe("no-store")
+  })
+
   it("exports a static matcher that covers application and API routes while excluding immutable assets", () => {
     expect(config).toEqual({
-      matcher: ["/((?!_next/static|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico|woff2?|ttf|wasm)$).*)"],
+      matcher: ["/((?!_next/static).*)"],
     })
+    const matcher = new RegExp(`^${config.matcher[0]}$`)
+
+    for (const pathname of ["/dashboard/acme/repo/blob/private.png", "/blog/diagram.svg", "/preview/sandbox"]) {
+      expect(matcher.test(pathname), pathname).toBe(true)
+    }
+
+    expect(matcher.test("/_next/static/chunks/app.js")).toBe(false)
   })
 })

--- a/lib/deployment-role.ts
+++ b/lib/deployment-role.ts
@@ -1,0 +1,10 @@
+const SANDBOX_PATH = "/preview/sandbox"
+const NEXT_ASSET_PREFIXES = ["/_next/static/", "/_next/image"] as const
+const PUBLIC_ASSET_EXTENSION = /\.(?:svg|png|jpe?g|gif|webp|ico|woff2?|ttf|wasm)$/i
+
+export function canServeDeploymentPath(pathname: string, deploymentRole = process.env.REPOPRESS_DEPLOYMENT_ROLE) {
+  if (deploymentRole !== "sandbox") return true
+  if (pathname === SANDBOX_PATH) return true
+  if (NEXT_ASSET_PREFIXES.some((prefix) => pathname.startsWith(prefix))) return true
+  return PUBLIC_ASSET_EXTENSION.test(pathname)
+}

--- a/lib/deployment-role.ts
+++ b/lib/deployment-role.ts
@@ -1,10 +1,10 @@
 const SANDBOX_PATH = "/preview/sandbox"
-const NEXT_ASSET_PREFIXES = ["/_next/static/", "/_next/image"] as const
+const NEXT_ASSET_PREFIX = "/_next/static/"
 const PUBLIC_ASSET_EXTENSION = /\.(?:svg|png|jpe?g|gif|webp|ico|woff2?|ttf|wasm)$/i
 
 export function canServeDeploymentPath(pathname: string, deploymentRole = process.env.REPOPRESS_DEPLOYMENT_ROLE) {
   if (deploymentRole !== "sandbox") return true
   if (pathname === SANDBOX_PATH) return true
-  if (NEXT_ASSET_PREFIXES.some((prefix) => pathname.startsWith(prefix))) return true
+  if (pathname.startsWith(NEXT_ASSET_PREFIX)) return true
   return PUBLIC_ASSET_EXTENSION.test(pathname)
 }

--- a/lib/deployment-role.ts
+++ b/lib/deployment-role.ts
@@ -1,10 +1,22 @@
 const SANDBOX_PATH = "/preview/sandbox"
 const NEXT_ASSET_PREFIX = "/_next/static/"
-const PUBLIC_ASSET_EXTENSION = /\.(?:svg|png|jpe?g|gif|webp|ico|woff2?|ttf|wasm)$/i
+const SANDBOX_PUBLIC_ASSETS = new Set([
+  "/apple-icon.png",
+  "/esbuild.wasm",
+  "/icon-dark-32x32.png",
+  "/icon-light-32x32.png",
+  "/icon.svg",
+])
+const READ_ONLY_METHODS = new Set(["GET", "HEAD"])
 
-export function canServeDeploymentPath(pathname: string, deploymentRole = process.env.REPOPRESS_DEPLOYMENT_ROLE) {
+export function canServeDeploymentRequest(
+  pathname: string,
+  method: string,
+  deploymentRole = process.env.REPOPRESS_DEPLOYMENT_ROLE,
+) {
   if (deploymentRole !== "sandbox") return true
+  if (!READ_ONLY_METHODS.has(method.toUpperCase())) return false
   if (pathname === SANDBOX_PATH) return true
   if (pathname.startsWith(NEXT_ASSET_PREFIX)) return true
-  return PUBLIC_ASSET_EXTENSION.test(pathname)
+  return SANDBOX_PUBLIC_ASSETS.has(pathname)
 }

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,4 +1,5 @@
 import { type NextRequest, NextResponse } from "next/server"
+import { canServeDeploymentPath } from "@/lib/deployment-role"
 
 const DASHBOARD_PATH = "/dashboard"
 const CONVEX_JWT_COOKIE_NAMES = ["better-auth.convex_jwt", "convex_jwt"] as const
@@ -16,6 +17,18 @@ function getAuthSignals(request: NextRequest) {
 
 export function proxy(request: NextRequest) {
   const { pathname, searchParams } = request.nextUrl
+
+  if (!canServeDeploymentPath(pathname)) {
+    return new NextResponse("Not Found", {
+      status: 404,
+      headers: {
+        "Cache-Control": "no-store",
+        "Content-Type": "text/plain; charset=utf-8",
+        "X-Content-Type-Options": "nosniff",
+      },
+    })
+  }
+
   const { hasPatAuth, isAuthenticated } = getAuthSignals(request)
   const isDashboardRoute = pathname === DASHBOARD_PATH || pathname.startsWith(`${DASHBOARD_PATH}/`)
   const isLoginRoute = pathname === "/login" || pathname.startsWith("/login/")
@@ -41,5 +54,5 @@ export function proxy(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ["/", "/login/:path*", "/dashboard/:path*"],
+  matcher: ["/((?!_next/static|_next/image|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico|woff2?|ttf|wasm)$).*)"],
 }

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,5 +1,5 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { canServeDeploymentPath } from "@/lib/deployment-role"
+import { canServeDeploymentRequest } from "@/lib/deployment-role"
 
 const DASHBOARD_PATH = "/dashboard"
 const CONVEX_JWT_COOKIE_NAMES = ["better-auth.convex_jwt", "convex_jwt"] as const
@@ -18,7 +18,7 @@ function getAuthSignals(request: NextRequest) {
 export function proxy(request: NextRequest) {
   const { pathname, searchParams } = request.nextUrl
 
-  if (!canServeDeploymentPath(pathname)) {
+  if (!canServeDeploymentRequest(pathname, request.method)) {
     return new NextResponse("Not Found", {
       status: 404,
       headers: {
@@ -54,5 +54,5 @@ export function proxy(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ["/((?!_next/static|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico|woff2?|ttf|wasm)$).*)"],
+  matcher: ["/((?!_next/static).*)"],
 }

--- a/proxy.ts
+++ b/proxy.ts
@@ -54,5 +54,5 @@ export function proxy(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ["/((?!_next/static|_next/image|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico|woff2?|ttf|wasm)$).*)"],
+  matcher: ["/((?!_next/static|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico|woff2?|ttf|wasm)$).*)"],
 }


### PR DESCRIPTION
## What changed

- surface returned and thrown GitHub OAuth failures on the login screen
- replace the bare global crash page with branded, actionable dashboard and application recovery states
- add a sandbox-only deployment role that serves only `/preview/sandbox` and immutable assets
- correct production auth and Compatible preview deployment documentation

## Root causes

- production Convex had no `SITE_URL`, so Better Auth rejected social sign-in with HTTP 403
- the login client ignored Better Auth's returned error object
- production Vercel had no RepoPress capability secret, causing repository pages to fail closed
- Vercel-protected preview deployments cannot be embedded as third-party iframes

## Impact

Production can use a separately hosted public Compatible preview origin without exposing Studio, auth, or mutation routes from that deployment. Authentication and repository failures now provide visible, accessible recovery paths.

## Verification

- TypeScript: clean
- Biome: 0 errors, same 8 pre-existing warnings
- Vitest: 152 files / 1,750 tests passed
- Next.js production build: passed with non-secret build-only Convex origins
- `git diff --check`: clean

## Deployment follow-up

After review and merge, configure production Convex `SITE_URL`, synchronize the existing capability secret into production Vercel, create the dedicated sandbox Vercel project, configure the P-256 signing pair/origin, and run Merry Magic Mail browser E2E.
