### PR TITLE
Fix production GitHub OAuth origin and callback

### DIFF
--- a/convex/auth.ts
+++ b/convex/auth.ts
@@ -2,6 +2,7 @@ import { createClient, type GenericCtx } from "@convex-dev/better-auth"
 import { convex } from "@convex-dev/better-auth/plugins"
 import { betterAuth } from "better-auth/minimal"
 import { v } from "convex/values"
+import { resolveAuthOrigin } from "../lib/auth-origin"
 import { verifyGitHubAccountLookupToken, verifyGitHubIdentityBootstrapToken } from "../lib/project-access-token"
 import { components } from "./_generated/api"
 import type { DataModel } from "./_generated/dataModel"
@@ -11,7 +12,7 @@ import authConfig from "./auth.config"
 // SITE_URL must be the app URL (not Convex site URL) so that OAuth
 // callbacks route through the Next.js proxy at /api/auth/[...all].
 // This ensures cookies are set on the app domain.
-const siteUrl = process.env.SITE_URL!
+const { githubCallbackURL, siteUrl, trustedOrigins } = resolveAuthOrigin(process.env.SITE_URL)
 
 // The component client has methods needed for integrating Convex with Better Auth
 export const authComponent = createClient<DataModel>(components.betterAuth)
@@ -19,11 +20,13 @@ export const authComponent = createClient<DataModel>(components.betterAuth)
 export const createAuth = (ctx: GenericCtx<DataModel>) => {
   return betterAuth({
     baseURL: siteUrl,
+    trustedOrigins,
     database: authComponent.adapter(ctx),
     socialProviders: {
       github: {
         clientId: process.env.GITHUB_CLIENT_ID!,
         clientSecret: process.env.GITHUB_CLIENT_SECRET!,
+        redirectURI: githubCallbackURL,
         scope: ["repo", "user"],
       },
     },

--- a/docs/plans/2026-08-02-production-hardening-design.md
+++ b/docs/plans/2026-08-02-production-hardening-design.md
@@ -24,7 +24,7 @@ Messages remain calm and specific: the workspace could not open, saved GitHub co
 
 Treat `signIn.social` as a result-bearing API. A returned Better Auth error becomes a visible destructive alert, thrown/network failures use a generic retry message, and successful results retain the requested safe in-app callback. Loading state always settles and duplicate submission remains disabled.
 
-Production Convex receives `SITE_URL=https://repo-press-itsyogesh.vercel.app`. The GitHub OAuth callback remains routed through `/api/auth/callback/github` on the application origin so the application domain receives the session cookies.
+Production Convex receives `SITE_URL=https://repo-press-itsyogesh.vercel.app`. Auth startup validates that value as a single application origin and uses it for Better Auth's `baseURL`, explicit `trustedOrigins`, and the GitHub provider's explicit `/api/auth/callback/github` redirect. This keeps both the sign-in request and callback on the application origin so the application domain receives the state and session cookies.
 
 ### Capability configuration
 
@@ -32,7 +32,7 @@ Copy the existing production Convex `REPOPRESS_CAPABILITY_SECRET` into productio
 
 ### Dedicated Compatible preview origin
 
-Add a deployment-role gate controlled by `REPOPRESS_DEPLOYMENT_ROLE=sandbox`. In sandbox mode, only `GET` and `HEAD` requests for `/preview/sandbox`, immutable Next.js bundles, and an exact allowlist of public assets required to render it are reachable; application, dashboard, auth, mutation, and dynamic extension-suffixed routes return 404. Normal Studio deployments are unchanged.
+Add a deployment-role gate controlled by `REPOPRESS_DEPLOYMENT_ROLE=sandbox`. In sandbox mode, only `GET` and `HEAD` requests for `/preview/sandbox`, immutable Next.js bundles, and an exact allowlist of public assets required to render it are reachable; application, dashboard, auth, mutation, and dynamic extension-suffixed routes return 404. A sandbox-only Vercel project route returns 404 for `/_next/image` before the managed optimizer can bypass Next.js Proxy. Normal Studio deployments are unchanged.
 
 Create a dedicated public Vercel sandbox project from the same reviewed commit. Generate one P-256 key pair: the private JWK is server-only in the Studio production environment, while the matching public JWK is browser-readable in both Studio and sandbox builds. The sandbox also receives the public Convex URL and site URL because the shared application build requires them; the role gate prevents those values from exposing application or API routes at runtime. Point `NEXT_PUBLIC_PREVIEW_ORIGIN` at the dedicated sandbox production origin. The sandbox remains public at the network edge because repository code is admitted only through RepoPress's signed approval protocol and executes inside the opaque iframe containment boundary.
 

--- a/docs/plans/2026-08-02-production-hardening.md
+++ b/docs/plans/2026-08-02-production-hardening.md
@@ -181,7 +181,9 @@ Create a dedicated Vercel project from the reviewed branch with:
 Keep the sandbox production deployment public; do not add Studio auth,
 `CONVEX_DEPLOYMENT`, the capability secret, or the private key. The deployment
 gate must still reject all runtime application/API routes and all non-GET/HEAD
-requests.
+requests. Add and publish a sandbox-only Vercel project route that sets status
+404 for the exact `/_next/image` path; the managed image optimizer is evaluated
+before Next.js Proxy in production.
 
 **Step 5: Push, open PR, review, and merge**
 

--- a/docs/production-deployment-guide.md
+++ b/docs/production-deployment-guide.md
@@ -35,7 +35,7 @@ Step-by-step instructions for deploying RepoPress to production. This guide cove
    | `GITHUB_CLIENT_SECRET` | Your GitHub OAuth App client secret | - |
    | `BETTER_AUTH_SECRET` | A new random 32+ character string | **Do NOT reuse the dev secret** |
    | `REPOPRESS_CAPABILITY_SECRET` | A new random 32+ character string | Also configure this exact value in Vercel; do not reuse `BETTER_AUTH_SECRET` |
-   | `SITE_URL` | `https://your-domain.com` | Public RepoPress application origin; Better Auth callbacks return through this origin |
+   | `SITE_URL` | `https://your-domain.com` | Exact public RepoPress application origin; Better Auth trusts it and sends GitHub callbacks through its Next.js auth proxy |
 
    Generate independent secrets for Better Auth and RepoPress capabilities:
    ```bash
@@ -111,6 +111,26 @@ public assets needed by that page. It must not receive the private signing JWK,
 GitHub credentials, auth secrets, `CONVEX_DEPLOYMENT`, or the RepoPress
 capability secret. The origin is public at the network edge because the signed
 approval protocol and opaque iframe are the execution boundary.
+
+Vercel's managed `/_next/image` endpoint is evaluated before Next.js Proxy in a
+production deployment. Add this project-level route to the **sandbox project
+only**, then publish the staged routing version:
+
+```bash
+vercel routes add "Block Next image optimizer" \
+  --src "/_next/image" \
+  --src-syntax equals \
+  --action set-status \
+  --status 404 \
+  --position start \
+  --yes
+vercel routes publish --yes
+```
+
+Without this edge rule, a syntactically valid local image request can reach
+Vercel's optimizer without invoking application middleware. Verify both the
+bare endpoint and a valid-looking request such as
+`/_next/image?url=%2Ficon-light-32x32.png&w=64&q=75` return 404.
 
 ---
 

--- a/lib/__tests__/auth-origin.test.ts
+++ b/lib/__tests__/auth-origin.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest"
+import { resolveAuthOrigin } from "@/lib/auth-origin"
+
+describe("resolveAuthOrigin", () => {
+  it("derives one trusted application origin and the GitHub proxy callback", () => {
+    expect(resolveAuthOrigin("https://repo-press.example/")).toEqual({
+      githubCallbackURL: "https://repo-press.example/api/auth/callback/github",
+      siteUrl: "https://repo-press.example",
+      trustedOrigins: ["https://repo-press.example"],
+    })
+  })
+
+  it("allows an HTTP localhost origin for local development", () => {
+    expect(resolveAuthOrigin("http://localhost:3001")).toEqual({
+      githubCallbackURL: "http://localhost:3001/api/auth/callback/github",
+      siteUrl: "http://localhost:3001",
+      trustedOrigins: ["http://localhost:3001"],
+    })
+  })
+
+  it("rejects plain HTTP for non-local application origins", () => {
+    expect(() => resolveAuthOrigin("http://repo-press.example")).toThrow(
+      "SITE_URL must be an absolute HTTPS application origin or an HTTP localhost origin",
+    )
+  })
+
+  it.each([
+    undefined,
+    "",
+    "repo-press.example",
+    "ftp://repo-press.example",
+    "https://user:password@repo-press.example",
+    "https://repo-press.example/app",
+    "https://repo-press.example?preview=1",
+    "https://repo-press.example#fragment",
+  ])("rejects an invalid SITE_URL value %s", (value) => {
+    expect(() => resolveAuthOrigin(value)).toThrow(
+      "SITE_URL must be an absolute HTTPS application origin or an HTTP localhost origin",
+    )
+  })
+})

--- a/lib/__tests__/pat-identity-bootstrap.test.ts
+++ b/lib/__tests__/pat-identity-bootstrap.test.ts
@@ -1,6 +1,10 @@
-import { beforeEach, describe, expect, it } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 import { resolveOrCreatePatUser } from "@/convex/auth"
 import { mintGitHubIdentityBootstrapToken } from "../project-access-token"
+
+vi.hoisted(() => {
+  process.env.SITE_URL = "https://repo-press.example"
+})
 
 const identity = {
   githubAccountId: "12345",

--- a/lib/auth-origin.ts
+++ b/lib/auth-origin.ts
@@ -1,0 +1,36 @@
+const AUTH_CALLBACK_PATH = "/api/auth/callback/github"
+const INVALID_SITE_URL_MESSAGE = "SITE_URL must be an absolute HTTPS application origin or an HTTP localhost origin"
+
+function isLocalHostname(hostname: string) {
+  return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "[::1]"
+}
+
+export function resolveAuthOrigin(value: string | undefined) {
+  if (!value?.trim()) throw new Error(INVALID_SITE_URL_MESSAGE)
+
+  try {
+    const trimmed = value.trim()
+    const url = new URL(trimmed)
+    if (
+      (url.protocol !== "https:" && !(url.protocol === "http:" && isLocalHostname(url.hostname))) ||
+      url.origin === "null" ||
+      url.username ||
+      url.password ||
+      (url.pathname !== "/" && url.pathname !== "") ||
+      url.search ||
+      url.hash
+    ) {
+      throw new Error(INVALID_SITE_URL_MESSAGE)
+    }
+
+    const siteUrl = url.origin
+    return {
+      githubCallbackURL: `${siteUrl}${AUTH_CALLBACK_PATH}`,
+      siteUrl,
+      trustedOrigins: [siteUrl],
+    }
+  } catch (error) {
+    if (error instanceof Error && error.message === INVALID_SITE_URL_MESSAGE) throw error
+    throw new Error(INVALID_SITE_URL_MESSAGE)
+  }
+}


### PR DESCRIPTION
## Summary
- validate SITE_URL as one HTTPS application origin (HTTP localhost only for development)
- use that origin explicitly for Better Auth baseURL, trustedOrigins, and the GitHub callback through the Next.js auth proxy
- document the sandbox-only Vercel /_next/image edge block discovered during live hardening

## Verification
- 153 test files / 1,777 tests pass
- TypeScript clean
- Biome: 0 errors / 8 inherited warnings
- production Next.js build passes with the approved public production URLs
- git diff --check clean

## Production follow-up
After merge, deploy Convex and both Vercel projects from the merged SHA, verify the GitHub OAuth App callback, then run the signed Compatible preview and Merry Magic Mail browser E2E.