### PR TITLE
Allow Convex static auth route registration

### DIFF
--- a/convex/auth.ts
+++ b/convex/auth.ts
@@ -9,15 +9,27 @@ import type { DataModel } from "./_generated/dataModel"
 import { mutation, query } from "./_generated/server"
 import authConfig from "./auth.config"
 
-// SITE_URL must be the app URL (not Convex site URL) so that OAuth
-// callbacks route through the Next.js proxy at /api/auth/[...all].
-// This ensures cookies are set on the app domain.
-const { githubCallbackURL, siteUrl, trustedOrigins } = resolveAuthOrigin(process.env.SITE_URL)
+const STATIC_REGISTRATION_ORIGIN = "https://static-auth.repopress.invalid"
+
+function resolveAuthOriginForContext(ctx: GenericCtx<DataModel>) {
+  // @convex-dev/better-auth calls createAuth({}) once while registering route
+  // metadata. Convex does the same during deploy analysis without exposing
+  // deployment environment variables. That static instance only contributes
+  // basePath; every request creates auth again with a real Convex context.
+  const isStaticRouteRegistration = Reflect.ownKeys(ctx as object).length === 0
+  const configuredOrigin =
+    isStaticRouteRegistration && !process.env.SITE_URL ? STATIC_REGISTRATION_ORIGIN : process.env.SITE_URL
+  return resolveAuthOrigin(configuredOrigin)
+}
 
 // The component client has methods needed for integrating Convex with Better Auth
 export const authComponent = createClient<DataModel>(components.betterAuth)
 
 export const createAuth = (ctx: GenericCtx<DataModel>) => {
+  // SITE_URL must be the app URL (not the Convex site URL) so callbacks
+  // traverse the Next.js proxy and cookies remain on the application origin.
+  const { githubCallbackURL, siteUrl, trustedOrigins } = resolveAuthOriginForContext(ctx)
+
   return betterAuth({
     baseURL: siteUrl,
     trustedOrigins,

--- a/lib/__tests__/auth-registration.test.ts
+++ b/lib/__tests__/auth-registration.test.ts
@@ -1,0 +1,27 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+const originalSiteUrl = process.env.SITE_URL
+
+describe("Convex Better Auth registration", () => {
+  afterEach(() => {
+    vi.resetModules()
+    if (originalSiteUrl === undefined) delete process.env.SITE_URL
+    else process.env.SITE_URL = originalSiteUrl
+  })
+
+  it("allows the empty static registration context without deployment environment variables", async () => {
+    delete process.env.SITE_URL
+    const { createAuth } = await import("@/convex/auth")
+
+    expect(() => createAuth({} as never)).not.toThrow()
+  })
+
+  it("still fails closed when a runtime context has no SITE_URL", async () => {
+    delete process.env.SITE_URL
+    const { createAuth } = await import("@/convex/auth")
+
+    expect(() => createAuth({ runQuery: vi.fn() } as never)).toThrow(
+      "SITE_URL must be an absolute HTTPS application origin or an HTTP localhost origin",
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- allow @convex-dev/better-auth's documented empty static route-registration call to construct auth while Convex deploy analysis hides environment variables
- keep SITE_URL fail-closed for every real Convex request context
- add regression coverage for both static registration and runtime rejection

## Verification
- production Convex deploy dry-run reaches schema validation and finalization successfully
- 154 test files / 1,779 tests pass
- TypeScript clean
- Biome: 0 errors / 8 inherited warnings
- production Next.js build passes
- git diff --check clean

This fixes the deployment-analysis failure found after PR #46 merged; no failed production deploy was applied.