### PR TITLE
Recognize Better Auth secure production JWT cookie

### DIFF
--- a/lib/__tests__/proxy.test.ts
+++ b/lib/__tests__/proxy.test.ts
@@ -63,6 +63,18 @@ describe("proxy.ts", () => {
     expect(response.headers.get("location")).toBe("https://repo-press.dev/dashboard")
   })
 
+  it("allows dashboard requests authenticated by the secure production Convex JWT cookie", () => {
+    const request = new NextRequest("https://repo-press.dev/dashboard", {
+      headers: {
+        cookie: "__Secure-better-auth.convex_jwt=valid-production-jwt",
+      },
+    })
+    const response = proxy(request)
+
+    expect(response.headers.get("location")).toBeNull()
+    expect(response.headers.get("x-middleware-next")).toBe("1")
+  })
+
   it("returns 404 for application and API routes in a sandbox-only deployment", () => {
     process.env.REPOPRESS_DEPLOYMENT_ROLE = "sandbox"
 

--- a/proxy.ts
+++ b/proxy.ts
@@ -2,7 +2,7 @@ import { type NextRequest, NextResponse } from "next/server"
 import { canServeDeploymentRequest } from "@/lib/deployment-role"
 
 const DASHBOARD_PATH = "/dashboard"
-const CONVEX_JWT_COOKIE_NAMES = ["better-auth.convex_jwt", "convex_jwt"] as const
+const CONVEX_JWT_COOKIE_NAMES = ["__Secure-better-auth.convex_jwt", "better-auth.convex_jwt", "convex_jwt"] as const
 
 function getAuthSignals(request: NextRequest) {
   const hasConvexJwt = CONVEX_JWT_COOKIE_NAMES.some((cookieName) => Boolean(request.cookies.get(cookieName)?.value))


### PR DESCRIPTION
## Summary

- recognize Better Auth's production `__Secure-better-auth.convex_jwt` cookie in the Next.js proxy
- preserve existing development and PAT cookie behavior
- add the exact production dashboard regression

## Live diagnosis

GitHub OAuth now completes and returns three app-domain cookies, but the proxy redirected `/dashboard` to `/login` because it only recognized the non-secure development cookie name.

## Verification

- focused auth/proxy suite: 30 tests pass
- full suite: 154 files / 1,780 tests pass
- TypeScript clean
- Biome clean on changed files
- git diff --check clean
