### PR TITLE
Fix config-root migration isolation

### DIFF
--- a/app/api/github/publish-ops/__tests__/route.test.ts
+++ b/app/api/github/publish-ops/__tests__/route.test.ts
@@ -304,6 +304,77 @@ describe("POST /api/github/publish-ops", () => {
     )
   })
 
+  it("isolates stale legacy rows while publishing current-root state", async () => {
+    mockPublishQueries({
+      pendingOps: [
+        {
+          _id: "op_stale",
+          opType: "delete",
+          filePath: "page",
+          pathRepresentation: undefined,
+          updatedAt: 1,
+        },
+      ],
+      dirtyDocs: [
+        {
+          _id: "doc_stale",
+          filePath: "page",
+          pathRepresentation: undefined,
+          body: "# Stale",
+          frontmatter: {},
+          updatedAt: 1,
+        },
+        {
+          _id: "doc_current",
+          filePath: "posts/current.mdx",
+          body: "# Current",
+          frontmatter: {},
+          updatedAt: 2,
+        },
+      ],
+    })
+
+    const response = await POST(buildRequest({ projectId: "project_123" }))
+    const payload = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(payload.ok).toBe(true)
+    const readPaths = vi.mocked(getFileForPublish).mock.calls.map((call) => call[3])
+    expect(readPaths).toContain("content/posts/current.mdx")
+    expect(readPaths).not.toContain("page")
+    expect(readPaths).not.toContain("content/page")
+  })
+
+  it("returns no-pending when every content row belongs to an earlier root", async () => {
+    mockPublishQueries({
+      pendingOps: [
+        {
+          _id: "op_stale",
+          opType: "delete",
+          filePath: "page",
+          pathRepresentation: undefined,
+          updatedAt: 1,
+        },
+      ],
+      dirtyDocs: [
+        {
+          _id: "doc_stale",
+          filePath: "page",
+          pathRepresentation: undefined,
+          body: "# Stale",
+          frontmatter: {},
+          updatedAt: 1,
+        },
+      ],
+    })
+
+    const response = await POST(buildRequest({ projectId: "project_123" }))
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({ error: "No pending changes to publish" })
+    expect(batchCommitPublishLaneAtExpectedHead).not.toHaveBeenCalled()
+  })
+
   it("creates a new PR when publishMode is create-new", async () => {
     mockPublishQueries({
       pendingOps: [],

--- a/app/api/github/publish-ops/route.ts
+++ b/app/api/github/publish-ops/route.ts
@@ -21,7 +21,7 @@ import {
   updatePullRequest,
   verifyPublishAttemptCommitForPublish,
 } from "@/lib/github"
-import { resolveStoredRepoPath, type StoredPathRepresentation } from "@/lib/preview/path-policy"
+import { type StoredPathRepresentation, toRepoPath, tryResolveStoredContentPath } from "@/lib/preview/path-policy"
 import { mintServerQueryToken } from "@/lib/project-access-token"
 import { buildPublishBranchName, derivePublishBranchScope } from "@/lib/publish-branch-name"
 import { detectMetadataSource, serializePublishContent } from "@/lib/publish-content"
@@ -133,22 +133,25 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: "No pending changes to publish" }, { status: 400 })
     }
 
-    const resolvedPendingOps = pendingOps.map((source) => ({
-      source,
-      repoPath: resolveStoredRepoPath(
+    const resolvedPendingOps = pendingOps.flatMap((source) => {
+      const contentPath = tryResolveStoredContentPath(
         contentRoot,
         source.filePath,
         source.pathRepresentation as StoredPathRepresentation | undefined,
-      ),
-    }))
-    const resolvedDirtyDocs = dirtyDocs.map((source) => ({
-      source,
-      repoPath: resolveStoredRepoPath(
+      )
+      return contentPath ? [{ source, repoPath: toRepoPath(contentRoot, contentPath) }] : []
+    })
+    const resolvedDirtyDocs = dirtyDocs.flatMap((source) => {
+      const contentPath = tryResolveStoredContentPath(
         contentRoot,
         source.filePath,
         source.pathRepresentation as StoredPathRepresentation | undefined,
-      ),
-    }))
+      )
+      return contentPath ? [{ source, repoPath: toRepoPath(contentRoot, contentPath) }] : []
+    })
+    if (resolvedPendingOps.length === 0 && resolvedDirtyDocs.length === 0 && pendingMediaOps.length === 0) {
+      return NextResponse.json({ error: "No pending changes to publish" }, { status: 400 })
+    }
     const identityConflicts = findContentIdentityConflicts(resolvedPendingOps, resolvedDirtyDocs)
     if (identityConflicts.length > 0) {
       return NextResponse.json({ ok: false, conflicts: identityConflicts }, { status: 409 })

--- a/components/studio/hooks/__tests__/use-studio-queries-paths.test.tsx
+++ b/components/studio/hooks/__tests__/use-studio-queries-paths.test.tsx
@@ -141,4 +141,44 @@ describe("useStudioQueries path ingress", () => {
     )
     expect(result!.document).toEqual(expect.objectContaining({ _id: "doc_legacy", filePath: "guides/start.mdx" }))
   })
+
+  it("isolates legacy rows left outside a config-synced content root", () => {
+    useQueryMock
+      .mockReturnValueOnce({ _id: "user_1" })
+      .mockReturnValueOnce({ _id: "project_123" })
+      .mockReturnValueOnce(null)
+      .mockReturnValueOnce(null)
+      .mockReturnValueOnce([
+        { filePath: "page", title: "Stale page" },
+        { filePath: "content/docs/guides/start.mdx", title: "Start" },
+      ])
+      .mockReturnValueOnce([
+        { _id: "op_stale", opType: "create", filePath: "page", status: "pending" },
+        {
+          _id: "op_current",
+          opType: "create",
+          filePath: "content/docs/guides/new.mdx",
+          status: "pending",
+        },
+      ])
+      .mockReturnValueOnce([])
+      .mockReturnValueOnce(null)
+      .mockReturnValueOnce(null)
+      .mockReturnValueOnce([])
+      .mockReturnValueOnce([
+        { _id: "doc_stale", filePath: "page" },
+        { _id: "doc_current", filePath: "content/docs/guides/edit.mdx" },
+      ])
+
+    let result: ReturnType<typeof useStudioQueries> | null = null
+    function Harness() {
+      result = useStudioQueries()
+      return null
+    }
+
+    expect(() => renderToStaticMarkup(<Harness />)).not.toThrow()
+    expect(result!.titleMap).toEqual({ "content/docs/guides/start.mdx": "Start" })
+    expect(result!.pendingOps).toEqual([expect.objectContaining({ _id: "op_current", filePath: "guides/new.mdx" })])
+    expect(result!.dirtyDocs).toEqual([expect.objectContaining({ _id: "doc_current", filePath: "guides/edit.mdx" })])
+  })
 })

--- a/components/studio/hooks/use-studio-queries.ts
+++ b/components/studio/hooks/use-studio-queries.ts
@@ -13,6 +13,7 @@ import {
   resolveStoredContentPath,
   type StoredPathRepresentation,
   toRepoPath,
+  tryResolveStoredContentPath,
 } from "@/lib/preview/path-policy"
 import { treePathToContentPath } from "@/lib/studio/path-adapters"
 import { useStudio } from "../studio-context"
@@ -252,29 +253,43 @@ export function useStudioQueries(
 
   const pendingOps = React.useMemo(
     () =>
-      storedPendingOps?.map((op) => ({
-        ...op,
-        filePath: resolveStoredContentPath(
+      storedPendingOps?.flatMap((op) => {
+        const filePath = tryResolveStoredContentPath(
           contentRoot,
           op.filePath,
           op.pathRepresentation as StoredPathRepresentation | undefined,
-        ),
-        pathRepresentation: CONTENT_PATH_REPRESENTATION,
-      })),
+        )
+        return filePath
+          ? [
+              {
+                ...op,
+                filePath,
+                pathRepresentation: CONTENT_PATH_REPRESENTATION,
+              },
+            ]
+          : []
+      }),
     [contentRoot, storedPendingOps],
   )
 
   const dirtyDocs = React.useMemo(
     () =>
-      storedDirtyDocs?.map((doc) => ({
-        ...doc,
-        filePath: resolveStoredContentPath(
+      storedDirtyDocs?.flatMap((doc) => {
+        const filePath = tryResolveStoredContentPath(
           contentRoot,
           doc.filePath,
           doc.pathRepresentation as StoredPathRepresentation | undefined,
-        ),
-        pathRepresentation: CONTENT_PATH_REPRESENTATION,
-      })),
+        )
+        return filePath
+          ? [
+              {
+                ...doc,
+                filePath,
+                pathRepresentation: CONTENT_PATH_REPRESENTATION,
+              },
+            ]
+          : []
+      }),
     [contentRoot, storedDirtyDocs],
   )
 
@@ -315,11 +330,12 @@ export function useStudioQueries(
     if (!titleEntries) return {}
     const map: Record<string, string> = {}
     for (const entry of titleEntries) {
-      const contentPath = resolveStoredContentPath(
+      const contentPath = tryResolveStoredContentPath(
         contentRoot,
         entry.filePath,
         entry.pathRepresentation as StoredPathRepresentation | undefined,
       )
+      if (!contentPath) continue
       map[toRepoPath(contentRoot, contentPath)] = entry.title
     }
     return map

--- a/convex/documents.ts
+++ b/convex/documents.ts
@@ -2,9 +2,9 @@ import { v } from "convex/values"
 import { DOCUMENT_ALLOWED_TRANSITIONS, isPublishableDocumentStatus } from "../lib/document-status"
 import {
   assertContentPath,
-  resolveStoredContentPath,
   type StoredPathRepresentation,
   toRepoPath,
+  tryResolveStoredContentPath,
 } from "../lib/preview/path-policy"
 import { verifyServerQueryToken } from "../lib/project-access-token"
 import { internal } from "./_generated/api"
@@ -1073,13 +1073,14 @@ export const syncTreeTitles = action({
       projectId: args.projectId,
     })
     const existingPaths = new Set(
-      existingDocs.map((document) =>
-        resolveStoredContentPath(
+      existingDocs.flatMap((document) => {
+        const contentPath = tryResolveStoredContentPath(
           project.contentRoot,
           document.filePath,
           document.pathRepresentation as StoredPathRepresentation | undefined,
-        ),
-      ),
+        )
+        return contentPath ? [contentPath] : []
+      }),
     )
 
     const missingFiles = files.filter((f) => !existingPaths.has(f.path))

--- a/convex/projects.ts
+++ b/convex/projects.ts
@@ -1,7 +1,8 @@
 import { v } from "convex/values"
 import { verifyProjectAccessToken, verifyServerQueryToken } from "../lib/project-access-token"
 import { internal } from "./_generated/api"
-import { internalMutation, internalQuery, mutation, query } from "./_generated/server"
+import type { Id } from "./_generated/dataModel"
+import { internalMutation, internalQuery, type MutationCtx, mutation, query } from "./_generated/server"
 import { authComponent } from "./auth"
 import { resolveProjectAccess, resolveProjectReader } from "./lib/access"
 
@@ -18,6 +19,52 @@ async function verifyCallerIdentity(ctx: Parameters<typeof authComponent.safeGet
     return
   }
   throw new Error("Unauthorized: Not authenticated")
+}
+
+async function assertSafeContentRootChange(
+  ctx: MutationCtx,
+  projectId: Id<"projects">,
+  currentRoot: string,
+  nextRoot: string,
+  configProjectId: string,
+) {
+  if (currentRoot === nextRoot) return
+
+  const rootScopedState = await Promise.all([
+    ctx.db
+      .query("documents")
+      .withIndex("by_projectId", (q) => q.eq("projectId", projectId))
+      .first(),
+    ctx.db
+      .query("explorerOps")
+      .withIndex("by_projectId", (q) => q.eq("projectId", projectId))
+      .first(),
+    ctx.db
+      .query("folderMeta")
+      .withIndex("by_projectId", (q) => q.eq("projectId", projectId))
+      .first(),
+    ctx.db
+      .query("collections")
+      .withIndex("by_projectId", (q) => q.eq("projectId", projectId))
+      .first(),
+    ctx.db
+      .query("mediaAssets")
+      .withIndex("by_projectId", (q) => q.eq("projectId", projectId))
+      .first(),
+    ctx.db
+      .query("mediaOps")
+      .withIndex("by_projectId", (q) => q.eq("projectId", projectId))
+      .first(),
+    ctx.db
+      .query("publishBranches")
+      .withIndex("by_projectId", (q) => q.eq("projectId", projectId))
+      .first(),
+  ])
+  if (rootScopedState.some(Boolean)) {
+    throw new Error(
+      `Project ${configProjectId} cannot change contentRoot while project content exists; use a new project id or clear the project first`,
+    )
+  }
 }
 
 // Authenticated version - gets projects for the current logged-in user.
@@ -627,6 +674,8 @@ export const syncProjectsFromConfig = mutation({
         )
 
       if (existing) {
+        await assertSafeContentRootChange(ctx, existing._id, existing.contentRoot, p.contentRoot, p.configProjectId)
+
         // Idempotency check: only patch if something actually changed
         const needsUpdate =
           existing.name !== p.name ||
@@ -750,7 +799,7 @@ export const update = mutation({
     components: v.optional(v.any()),
   },
   handler: async (ctx, args) => {
-    await resolveProjectAccess(
+    const { project } = await resolveProjectAccess(
       ctx,
       {
         projectId: args.id,
@@ -759,6 +808,10 @@ export const update = mutation({
       },
       "editor",
     )
+
+    if (args.contentRoot !== undefined) {
+      await assertSafeContentRootChange(ctx, project._id, project.contentRoot, args.contentRoot, project.name)
+    }
 
     const { id, userId: _userId, projectAccessToken: _pat, ...updates } = args
     await ctx.db.patch(id, {

--- a/lib/__tests__/convex-action-boundaries.test.ts
+++ b/lib/__tests__/convex-action-boundaries.test.ts
@@ -835,6 +835,29 @@ describe("public Convex GitHub action boundaries", () => {
     })
   })
 
+  it("ignores legacy document rows left outside a config-synced content root", async () => {
+    const ctx = actionCtx()
+    authorizeEditor(ctx, [{ _id: "stale_document", filePath: "page", title: "Stale page" }])
+
+    await (syncTreeTitles as any).handler(ctx, {
+      projectId: "project_1",
+      readRef: BASE_SHA,
+      files: [{ path: "guide.mdx", sha: "f".repeat(40) }],
+      githubToken: "editor-token",
+    })
+
+    expect(ctx.runMutation.mock.calls[1][1]).toEqual({
+      projectId: "project_1",
+      documents: [
+        {
+          filePath: "guide.mdx",
+          title: "Guide",
+          githubSha: "f".repeat(40),
+        },
+      ],
+    })
+  })
+
   it("rejects a gallery scan that forges the project owner through userId", async () => {
     const ctx = actionCtx()
     ctx.runQuery.mockResolvedValue(true)

--- a/lib/__tests__/convex-ownership-guards.test.ts
+++ b/lib/__tests__/convex-ownership-guards.test.ts
@@ -82,6 +82,32 @@ describe("Convex ownership guards", () => {
     expect(ctx.db.patch).not.toHaveBeenCalled()
   })
 
+  it("rejects project content-root changes while path-scoped state exists", async () => {
+    const patch = vi.fn()
+    const ctx = createCtx({
+      get: vi.fn().mockResolvedValue({
+        _id: "project_1",
+        userId: "user_owner",
+        repoOwner: "acme",
+        repoName: "docs",
+        name: "Docs",
+        contentRoot: "content/blog",
+      }),
+      patch,
+      queryResult: { _id: "document_1" },
+    })
+
+    await expect(
+      (updateProject as any).handler(ctx, {
+        id: "project_1",
+        userId: "user_owner",
+        contentRoot: "content/docs",
+      }),
+    ).rejects.toThrow("cannot change contentRoot while project content exists")
+
+    expect(patch).not.toHaveBeenCalled()
+  })
+
   it("rejects project deletes when the authenticated user does not own the project", async () => {
     const ctx = createCtx({
       get: vi.fn().mockResolvedValue({ _id: "project_1", userId: "user_other", repoOwner: "acme", repoName: "docs" }),

--- a/lib/__tests__/sync-projects-from-config.test.ts
+++ b/lib/__tests__/sync-projects-from-config.test.ts
@@ -78,6 +78,7 @@ function makeProject(overrides: Partial<ProjectRow> & { _id: string }): ProjectR
 function createCtx({
   repoProjects = [] as ProjectRow[],
   tombstone = null as Partial<ProjectRow> | null,
+  rootScopedStateTables = [] as string[],
   patch = vi.fn(),
   insert = vi.fn().mockResolvedValue("new_project_id"),
 } = {}) {
@@ -97,6 +98,12 @@ function createCtx({
           if (table === "deletedConfigProjects") {
             return {
               first: vi.fn().mockResolvedValue(tombstone),
+            }
+          }
+          if (rootScopedStateTables.includes(table)) {
+            return {
+              collect: vi.fn().mockResolvedValue([]),
+              first: vi.fn().mockResolvedValue({ _id: `${table}_1` }),
             }
           }
           return {
@@ -265,6 +272,36 @@ describe("syncProjectsFromConfig", () => {
       expect(patch).toHaveBeenCalledWith("legacy_proj", expect.objectContaining({ configProjectId: "docs" }))
       expect(result.synced).toContain("legacy_proj")
       expect(result.created).toHaveLength(0)
+    })
+
+    it("rejects an in-place content-root change when path-scoped state exists", async () => {
+      const existing = makeProject({
+        _id: "proj_1",
+        configProjectId: "docs",
+        contentRoot: "content/blog",
+      })
+      const patch = vi.fn()
+      const ctx = createCtx({ repoProjects: [existing], rootScopedStateTables: ["documents"], patch })
+
+      await expect((syncProjectsFromConfig as any).handler(ctx, BASE_ARGS)).rejects.toThrow(
+        "cannot change contentRoot while project content exists",
+      )
+      expect(patch).not.toHaveBeenCalled()
+    })
+
+    it("allows a content-root correction before any path-scoped state exists", async () => {
+      const existing = makeProject({
+        _id: "proj_1",
+        configProjectId: "docs",
+        contentRoot: "content/blog",
+      })
+      const patch = vi.fn()
+      const ctx = createCtx({ repoProjects: [existing], patch })
+
+      const result = await (syncProjectsFromConfig as any).handler(ctx, BASE_ARGS)
+
+      expect(patch).toHaveBeenCalledWith("proj_1", expect.objectContaining({ contentRoot: "content/docs" }))
+      expect(result.synced).toContain("proj_1")
     })
   })
 

--- a/lib/preview/__tests__/path-policy.test.ts
+++ b/lib/preview/__tests__/path-policy.test.ts
@@ -6,6 +6,7 @@ import {
   toContentPath,
   toRepoPath,
   toRepoPathFromLegacyRepoPath,
+  tryResolveStoredContentPath,
 } from "../path-policy"
 
 describe("content path policy", () => {
@@ -51,6 +52,21 @@ describe("content path policy", () => {
 
   it("rejects unknown stored path representation tags", () => {
     expect(() => resolveStoredRepoPath("content/docs", "guides/start.mdx", "guessed" as never)).toThrow(
+      "unknown path representation",
+    )
+  })
+
+  it("isolates only expected legacy rows from an earlier content root", () => {
+    expect(tryResolveStoredContentPath("content/docs", "page")).toBeNull()
+    expect(tryResolveStoredContentPath("content/docs", "content/docs", "legacy_repo_v0")).toBeNull()
+
+    expect(() => tryResolveStoredContentPath("content/docs", "../page.mdx", "legacy_repo_v0")).toThrow(
+      "escapes content root",
+    )
+    expect(() => tryResolveStoredContentPath("content/docs", "../page.mdx", "content_relative_v1")).toThrow(
+      "escapes content root",
+    )
+    expect(() => tryResolveStoredContentPath("content/docs", "page.mdx", "unknown" as never)).toThrow(
       "unknown path representation",
     )
   })

--- a/lib/preview/path-policy.ts
+++ b/lib/preview/path-policy.ts
@@ -125,6 +125,31 @@ export function resolveStoredContentPath(
   throw new PathPolicyError("UNSAFE_RELATIVE_PATH", "unknown path representation")
 }
 
+/**
+ * Resolve persisted path state without allowing a legacy row from an older
+ * project content root to take down the current workspace. Invalid persisted
+ * rows are isolated; unexpected programmer/runtime failures still propagate.
+ */
+export function tryResolveStoredContentPath(
+  contentRoot: string,
+  storedPath: string,
+  representation?: StoredPathRepresentation,
+): string | null {
+  const isLegacyRepresentation = representation === undefined || representation === "legacy_repo_v0"
+  try {
+    return resolveStoredContentPath(contentRoot, storedPath, representation)
+  } catch (error) {
+    if (
+      isLegacyRepresentation &&
+      error instanceof PathPolicyError &&
+      (error.code === "DOCUMENT_OUTSIDE_CONTENT_ROOT" || error.code === "EMPTY_DOCUMENT_PATH")
+    ) {
+      return null
+    }
+    throw error
+  }
+}
+
 /** Convert a repository-relative file path into the canonical stored form. */
 export function toContentPath(contentRoot: string, repoPath: string): string {
   const root = normalizeContentRoot(contentRoot)


### PR DESCRIPTION
## Summary

- isolate legacy document and explorer rows left outside a config-synced content root
- apply the same narrow isolation in Studio, title sync, and publish planning
- reject in-place content-root changes once root-scoped project state exists

## Verification

- 154 test files / 1,788 tests passed
- TypeScript clean
- Biome clean on changed files
- git diff --check clean
- independent security/correctness review approved

## Production reproduction

This fixes the Merry Magic Mail project after its saved root moved from a legacy value to `apps/web/app/(main)/blog`. The old untagged title rows no longer crash Studio or poison publishing, while malformed canonical state still fails closed.
