### PR TITLE
fix: preserve remote MDX during Studio hydration

### DIFF
--- a/app/dashboard/[owner]/[repo]/studio/[[...path]]/__tests__/page-authoring-catalog.test.tsx
+++ b/app/dashboard/[owner]/[repo]/studio/[[...path]]/__tests__/page-authoring-catalog.test.tsx
@@ -141,6 +141,37 @@ describe("authenticated Studio registry authoring", () => {
     )
   })
 
+  it("resolves catch-all deep links relative to the configured content root", async () => {
+    vi.mocked(loadProjectLockAuthoringMetadata).mockResolvedValue({
+      baseSha: BASE_SHA,
+      lockPath: null,
+      metadata: Object.freeze({}),
+      diagnostics: Object.freeze([]),
+    })
+
+    const page = await StudioPage({
+      params: Promise.resolve({
+        owner: "acme",
+        repo: "docs",
+        path: ["guides", "getting-started.mdx"],
+      }),
+      searchParams: Promise.resolve({ branch: "release", projectId: "project-1" }),
+    })
+    render(page)
+
+    expect(getFile).toHaveBeenCalledWith(
+      "github-token",
+      "acme",
+      "docs",
+      "apps/docs/content/guides/getting-started.mdx",
+      BASE_SHA,
+    )
+    expect(StudioLayout).toHaveBeenCalledWith(
+      expect.objectContaining({ currentPath: "apps/docs/content/guides/getting-started.mdx" }),
+      undefined,
+    )
+  })
+
   it("fails closed before content reads when the branch head cannot be resolved", async () => {
     vi.mocked(getBranchHeadSha).mockRejectedValue(new Error("head unavailable"))
 

--- a/app/dashboard/[owner]/[repo]/studio/[[...path]]/page.tsx
+++ b/app/dashboard/[owner]/[repo]/studio/[[...path]]/page.tsx
@@ -5,6 +5,7 @@ import type { Doc, Id } from "@/convex/_generated/dataModel"
 import { getGitHubToken } from "@/lib/auth-server"
 import { createGitHubClient, getBranchHeadSha, getFile } from "@/lib/github"
 import { resolveRepoRole } from "@/lib/github-permissions"
+import { toRepoPath } from "@/lib/preview/path-policy"
 import { resolveProjectAccessRole } from "@/lib/project-access-role"
 import { mintProjectAccessToken } from "@/lib/project-access-token"
 import { loadProjectLockAuthoringMetadata } from "@/lib/repopress/project-lock-snapshot"
@@ -38,7 +39,6 @@ export default async function StudioPage({
 
   const { owner, repo, path } = resolvedParams
   const { branch, projectId: projectIdParam, file } = resolvedSearchParams
-  const currentPath = file || (path ? path.join("/") : "")
 
   const actingUserId = await resolveActingUserId(token)
   const { convex, serverQueryToken } = await createServerQueryContext()
@@ -118,6 +118,10 @@ export default async function StudioPage({
   }
 
   const contentRoot = project?.contentRoot || ""
+  // Query-string navigation is emitted by the repository tree and is already
+  // repository-relative. Catch-all route links are authored relative to the
+  // configured content root, so normalize them at the Git boundary.
+  const currentPath = file || (path?.length ? toRepoPath(contentRoot, path.join("/")) : "")
 
   let registryAuthoringMetadata = Object.freeze({})
   let registryAuthoringDiagnostics: readonly string[] = Object.freeze([])

--- a/components/studio/hooks/__tests__/use-studio-file-read-authority.test.tsx
+++ b/components/studio/hooks/__tests__/use-studio-file-read-authority.test.tsx
@@ -173,6 +173,37 @@ describe("useStudioFile immutable read authority", () => {
     expect(result.current.isDirty).toBe(true)
   })
 
+  it("does not let a title-only Convex row replace an in-flight GitHub snapshot", async () => {
+    studioContext.tree = []
+    const response = deferred<Response>()
+    vi.mocked(fetch).mockReturnValueOnce(response.promise)
+    const { result } = renderHook(() => useStudioFile(null, ""))
+
+    act(() => result.current.navigateToFile("content/article.mdx"))
+    await waitFor(() => expect(fetch).toHaveBeenCalledOnce())
+
+    act(() => {
+      result.current.hydrateFromDocument({})
+    })
+
+    await act(async () =>
+      response.resolve({
+        ok: true,
+        json: async () => ({
+          path: "content/article.mdx",
+          name: "article.mdx",
+          sha: "d".repeat(40),
+          content: "# Remote article\n\n<Component />",
+        }),
+      } as Response),
+    )
+
+    await waitFor(() => expect(result.current.content).toContain("# Remote article"))
+    expect(result.current.content).toContain("<Component />")
+    expect(result.current.sha).toBe("d".repeat(40))
+    expect(result.current.isDirty).toBe(false)
+  })
+
   it("preserves a late primed snapshot when the cold read returns 404", async () => {
     studioContext.tree = []
     const response = deferred<Response>()

--- a/components/studio/hooks/__tests__/use-studio-file-read-authority.test.tsx
+++ b/components/studio/hooks/__tests__/use-studio-file-read-authority.test.tsx
@@ -244,6 +244,30 @@ describe("useStudioFile immutable read authority", () => {
     expect(result.current.sha).toBeNull()
   })
 
+  it("preserves unsaved edits when a Convex draft arrives after the GitHub snapshot", async () => {
+    const { result } = renderHook(() => useStudioFile(null, ""))
+
+    act(() => result.current.navigateToFile("content/guide.mdx"))
+    await waitFor(() => expect(result.current.content).toBe("# Base snapshot"))
+
+    act(() => result.current.setContent("# Unsaved local edit"))
+    act(() => result.current.setFrontmatterKey("description", "Unsaved description"))
+    expect(result.current.isDirty).toBe(true)
+
+    let draftHandled: unknown
+    act(() => {
+      draftHandled = result.current.hydrateFromDocument({
+        body: "# Older saved draft",
+        frontmatter: { description: "Older description" },
+      })
+    })
+
+    expect(draftHandled).toBe(true)
+    expect(result.current.content).toBe("# Unsaved local edit")
+    expect(result.current.frontmatter).toEqual({ description: "Unsaved description" })
+    expect(result.current.isDirty).toBe(true)
+  })
+
   it("resolves pathname popstate links relative to contentRoot while leaving query paths repository-relative", async () => {
     studioContext.tree = []
     const { result } = renderHook(() => useStudioFile(null, ""))

--- a/components/studio/hooks/__tests__/use-studio-file-read-authority.test.tsx
+++ b/components/studio/hooks/__tests__/use-studio-file-read-authority.test.tsx
@@ -1,4 +1,4 @@
-import { act, renderHook, waitFor } from "@testing-library/react"
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 const BASE_SHA = "a".repeat(40)
@@ -44,6 +44,7 @@ describe("useStudioFile immutable read authority", () => {
   })
 
   afterEach(() => {
+    cleanup()
     vi.unstubAllGlobals()
     localStorage.clear()
   })
@@ -202,6 +203,57 @@ describe("useStudioFile immutable read authority", () => {
     expect(result.current.content).toContain("<Component />")
     expect(result.current.sha).toBe("d".repeat(40))
     expect(result.current.isDirty).toBe(false)
+  })
+
+  it("exposes title-only versus real empty-draft hydration during an in-flight read", async () => {
+    studioContext.tree = []
+    const response = deferred<Response>()
+    vi.mocked(fetch).mockReturnValueOnce(response.promise)
+    const { result } = renderHook(() => useStudioFile(null, ""))
+
+    act(() => result.current.navigateToFile("content/new.mdx"))
+    await waitFor(() => expect(fetch).toHaveBeenCalledOnce())
+
+    let titleOnlyHydrated: unknown
+    act(() => {
+      titleOnlyHydrated = result.current.hydrateFromDocument({})
+    })
+    expect(titleOnlyHydrated).toBe(false)
+
+    let emptyDraftHydrated: unknown
+    act(() => {
+      emptyDraftHydrated = result.current.hydrateFromDocument({ body: "", frontmatter: {} })
+    })
+    expect(emptyDraftHydrated).toBe(true)
+
+    await act(async () =>
+      response.resolve({
+        ok: true,
+        json: async () => ({
+          path: "content/new.mdx",
+          name: "new.mdx",
+          sha: "e".repeat(40),
+          content: "# Remote file at colliding path",
+        }),
+      } as Response),
+    )
+
+    await waitFor(() => expect(result.current.isFileLoading).toBe(false))
+    expect(result.current.content).toBe("")
+    expect(result.current.frontmatter).toEqual({})
+    expect(result.current.sha).toBeNull()
+  })
+
+  it("resolves pathname popstate links relative to contentRoot while leaving query paths repository-relative", async () => {
+    studioContext.tree = []
+    const { result } = renderHook(() => useStudioFile(null, ""))
+
+    window.history.replaceState({}, "", "/dashboard/acme/docs/studio/guides/getting-started.mdx?branch=release")
+    act(() => window.dispatchEvent(new PopStateEvent("popstate")))
+
+    await waitFor(() => expect(fetch).toHaveBeenCalledOnce())
+    expect(String(vi.mocked(fetch).mock.calls[0][0])).toContain("path=content%2Fguides%2Fgetting-started.mdx")
+    await waitFor(() => expect(result.current.selectedFile?.path).toBe("content/guides/getting-started.mdx"))
   })
 
   it("preserves a late primed snapshot when the cold read returns 404", async () => {

--- a/components/studio/hooks/use-studio-file.ts
+++ b/components/studio/hooks/use-studio-file.ts
@@ -527,6 +527,10 @@ export function useStudioFile(initialFile: InitialFile | null | undefined, curre
         if (!activePath) return false
 
         const cached = fileCacheRef.current.get(activePath)
+        // The editor is interactive before the Convex query necessarily
+        // settles. Never let a late saved draft overwrite newer local input.
+        if (cached?.isDirty) return true
+
         let nextContent = cached?.content ?? ""
         let nextFrontmatter = cached?.frontmatter ?? {}
         const currentSha = cached?.sha ?? null

--- a/components/studio/hooks/use-studio-file.ts
+++ b/components/studio/hooks/use-studio-file.ts
@@ -4,6 +4,7 @@ import matter from "gray-matter"
 import * as React from "react"
 import { normalizeFrontmatterDates } from "@/lib/framework-adapters"
 import { type FileTreeNode, findTreeNode } from "@/lib/github"
+import { toRepoPath } from "@/lib/preview/path-policy"
 import { useStudio } from "../studio-context"
 
 interface InitialFile {
@@ -55,7 +56,7 @@ function parseFileSnapshot(rawContent: string, sha: string | null): CachedFileSn
 }
 
 export function useStudioFile(initialFile: InitialFile | null | undefined, currentPath: string) {
-  const { owner, repo, branch, baseCommitSha, projectId, tree } = useStudio()
+  const { owner, repo, branch, baseCommitSha, projectId, contentRoot, tree } = useStudio()
   const openFilesStorageKey = React.useMemo(
     () => `studio:openFiles:${owner}:${repo}:${branch}:${projectId || "none"}`,
     [owner, repo, branch, projectId],
@@ -302,11 +303,11 @@ export function useStudioFile(initialFile: InitialFile | null | undefined, curre
     const prefix = `/dashboard/${owner}/${repo}/studio/`
     if (url.pathname.startsWith(prefix)) {
       const rawPath = url.pathname.slice(prefix.length)
-      if (rawPath) return decodeURIComponent(rawPath)
+      if (rawPath) return toRepoPath(contentRoot, decodeURIComponent(rawPath))
     }
 
     return ""
-  }, [owner, repo])
+  }, [owner, repo, contentRoot])
 
   React.useEffect(() => {
     try {
@@ -520,10 +521,10 @@ export function useStudioFile(initialFile: InitialFile | null | undefined, curre
         const draftFrontmatter = doc.frontmatter && typeof doc.frontmatter === "object" ? doc.frontmatter : null
         // Title synchronization creates index rows without draft content. Those
         // rows must not become empty local snapshots that outrank the Git read.
-        if (draftBody === null && draftFrontmatter === null) return
+        if (draftBody === null && draftFrontmatter === null) return false
 
         const activePath = selectedFile?.path
-        if (!activePath) return
+        if (!activePath) return false
 
         const cached = fileCacheRef.current.get(activePath)
         let nextContent = cached?.content ?? ""
@@ -550,8 +551,10 @@ export function useStudioFile(initialFile: InitialFile | null | undefined, curre
         })
 
         setIsDirty(false)
+        return true
       } catch (error) {
         console.error("Error hydrating from Convex document draft:", error)
+        return false
       }
     },
     [selectedFile?.path, writeCachedSnapshot],

--- a/components/studio/hooks/use-studio-file.ts
+++ b/components/studio/hooks/use-studio-file.ts
@@ -516,6 +516,12 @@ export function useStudioFile(initialFile: InitialFile | null | undefined, curre
   const hydrateFromDocument = React.useCallback(
     (doc: { body?: unknown; frontmatter?: unknown }) => {
       try {
+        const draftBody = typeof doc.body === "string" ? doc.body : null
+        const draftFrontmatter = doc.frontmatter && typeof doc.frontmatter === "object" ? doc.frontmatter : null
+        // Title synchronization creates index rows without draft content. Those
+        // rows must not become empty local snapshots that outrank the Git read.
+        if (draftBody === null && draftFrontmatter === null) return
+
         const activePath = selectedFile?.path
         if (!activePath) return
 
@@ -524,12 +530,12 @@ export function useStudioFile(initialFile: InitialFile | null | undefined, curre
         let nextFrontmatter = cached?.frontmatter ?? {}
         const currentSha = cached?.sha ?? null
 
-        if (typeof doc.body === "string") {
-          nextContent = doc.body
-          setContent(doc.body)
+        if (draftBody !== null) {
+          nextContent = draftBody
+          setContent(draftBody)
         }
-        if (doc.frontmatter && typeof doc.frontmatter === "object") {
-          nextFrontmatter = normalizeFrontmatterDates(doc.frontmatter as Record<string, unknown>) as Record<
+        if (draftFrontmatter !== null) {
+          nextFrontmatter = normalizeFrontmatterDates(draftFrontmatter as Record<string, unknown>) as Record<
             string,
             unknown
           >

--- a/components/studio/studio-layout.tsx
+++ b/components/studio/studio-layout.tsx
@@ -571,10 +571,9 @@ function StudioLayoutInner({
     if (!document || hydratedForPath.current === selectedPath) return
 
     const draftStatuses = new Set(["draft", "in_review", "approved"])
-    if (draftStatuses.has(document.status)) {
-      hydrateFromDocument(document)
+    if (draftStatuses.has(document.status) && hydrateFromDocument(document)) {
+      hydratedForPath.current = selectedPath
     }
-    hydratedForPath.current = selectedPath
   }, [document, selectedFile?.path, hydrateFromDocument])
 
   // Explorer mutations


### PR DESCRIPTION
## Summary
- prevent title-only Convex index rows from replacing an in-flight GitHub MDX snapshot with empty content
- resolve catch-all Studio deep links relative to the configured content root
- add regression coverage for both production failures

## Verification
- 154 test files / 1790 tests passed
- TypeScript passed
- changed-file Biome checks passed
- repository lint passed with 8 pre-existing warnings
- production-configured Vercel build passed