### PR TITLE
Surface compatible preview verification failures

### DIFF
--- a/components/studio/__tests__/preview-compatible-downgrade.test.tsx
+++ b/components/studio/__tests__/preview-compatible-downgrade.test.tsx
@@ -67,6 +67,7 @@ import { Preview } from "../preview"
 
 let firstWire: string
 let changedWire: string
+let untrustedWire: string
 let authority: CompatiblePreviewAuthorityContext
 let publicKey: JsonWebKey
 
@@ -76,8 +77,10 @@ beforeAll(async () => {
     documentSource: "# Changed static",
     keyPair: first.keyPair,
   })
+  const untrusted = await createSignedCompatibleFixture({ documentSource: "# Untrusted" })
   firstWire = first.wire
   changedWire = changed.wire
+  untrustedWire = untrusted.wire
   authority = first.expectedAuthority
   publicKey = first.publicKey
 })
@@ -203,6 +206,16 @@ describe("Studio compatible downgrade", () => {
     )
     expect(await screen.findByTitle("Compatible component preview")).toBeInTheDocument()
     await waitFor(() => expect(frameHarness.mounts).toBe(2))
+  })
+
+  it("explains a browser-side approval rejection instead of silently showing Generic fidelity", async () => {
+    renderCompatible(untrustedWire)
+
+    expect(await screen.findByRole("heading", { name: "Generic fallback" })).toBeInTheDocument()
+    expect(
+      await screen.findByText("The compatible preview approval failed its authenticity check."),
+    ).toBeInTheDocument()
+    expect(screen.queryByTitle("Compatible component preview")).not.toBeInTheDocument()
   })
 
   it.each([

--- a/components/studio/preview.tsx
+++ b/components/studio/preview.tsx
@@ -12,9 +12,10 @@ import { resolveFieldValue } from "@/lib/framework-adapters"
 import {
   COMPATIBLE_RENDERER_PROFILE,
   type CompatiblePreviewAuthorityContext,
+  type CompatiblePreviewVerificationFailureReason,
   parseConfiguredPreviewApprovalKey,
   type VerifiedCompatiblePreviewResolution,
-  verifySignedCompatiblePreviewResolution,
+  verifySignedCompatiblePreviewResolutionDetailed,
 } from "@/lib/preview/compatible-artifact"
 import {
   COMPATIBLE_FAILURE_MESSAGES,
@@ -139,6 +140,15 @@ const DOWNGRADE_MESSAGES: Readonly<Record<string, string>> = Object.freeze({
   BROWSER_CAPABILITY_UNSUPPORTED: "This component uses capabilities unavailable in compatible preview.",
 })
 
+const COMPATIBLE_VERIFICATION_MESSAGES: Readonly<Record<CompatiblePreviewVerificationFailureReason, string>> =
+  Object.freeze({
+    RESOLUTION_INVALID: "The compatible preview approval response was invalid.",
+    APPROVAL_EXPIRED: "The compatible preview approval expired; reload the document to retry.",
+    CRYPTO_UNAVAILABLE: "This browser cannot verify compatible preview approvals.",
+    SIGNATURE_INVALID: "The compatible preview approval failed its authenticity check.",
+    DIGEST_MISMATCH: "The compatible preview artifact did not match its approved content digest.",
+  })
+
 const MISSING_COMPATIBLE_FALLBACK_MODEL = freezePreviewValue<GenericRenderModel>({
   blocks: [{ type: "component-placeholder", name: "CompatiblePreview" }],
 })
@@ -221,6 +231,8 @@ export function Preview({
     authorityKey: string
     resolution: VerifiedCompatiblePreviewResolution
   } | null>(null)
+  const [compatibleVerificationFailure, setCompatibleVerificationFailure] =
+    React.useState<CompatiblePreviewVerificationFailureReason | null>(null)
   const [downgradedAttempt, setDowngradedAttempt] = React.useState<{
     key: string
     diagnostics: readonly string[]
@@ -232,13 +244,19 @@ export function Preview({
   React.useEffect(() => {
     let active = true
     setVerifiedCompatibleState(null)
+    setCompatibleVerificationFailure(null)
     if (compatibleContractMatches && compatibleResolution && compatibleAuthority && approvalPublicKey) {
       const authorityKey = compatibleAuthorityKey(compatibleAuthority)
-      void verifySignedCompatiblePreviewResolution(compatibleResolution, {
+      void verifySignedCompatiblePreviewResolutionDetailed(compatibleResolution, {
         publicKey: approvalPublicKey,
         expectedAuthority: compatibleAuthority,
-      }).then((resolution) => {
-        if (active && resolution) setVerifiedCompatibleState({ wire: compatibleResolution, authorityKey, resolution })
+      }).then((result) => {
+        if (!active) return
+        if (result.ok) {
+          setVerifiedCompatibleState({ wire: compatibleResolution, authorityKey, resolution: result.resolution })
+          return
+        }
+        setCompatibleVerificationFailure(result.reason)
       })
     }
     return () => {
@@ -276,8 +294,17 @@ export function Preview({
     ) {
       reasons.push(normalizePreviewDowngradeReason("COMPATIBLE_UNAVAILABLE"))
     }
+    if (activePreviewResult?.fidelity === "compatible" && compatibleVerificationFailure) {
+      reasons.push(COMPATIBLE_VERIFICATION_MESSAGES[compatibleVerificationFailure])
+    }
     return [...new Set(reasons)]
-  }, [activePreviewResult, approvalPublicKey, compatibleContractMatches, compatibleResolution])
+  }, [
+    activePreviewResult,
+    approvalPublicKey,
+    compatibleContractMatches,
+    compatibleResolution,
+    compatibleVerificationFailure,
+  ])
   const visibleDowngradeDiagnostics = compatibleDowngraded ? compatibleDiagnostics : downgradeDiagnostics
   const warnings = React.useMemo(() => {
     if (compatibleDowngraded) return [...compatibleDiagnostics]

--- a/lib/preview/__tests__/compatible-artifact.test.ts
+++ b/lib/preview/__tests__/compatible-artifact.test.ts
@@ -165,6 +165,14 @@ describe("compatible artifact transport", () => {
       ...trusted.resolution,
       artifact: { ...trusted.resolution.artifact, documentSource: "# Changed after approval" },
     }
+    const tamperedExpired = {
+      ...trusted.resolution,
+      authority: {
+        ...trusted.resolution.authority,
+        issuedAt: Date.now() - 120_000,
+        expiresAt: Date.now() - 60_000,
+      },
+    }
 
     await expect(
       verifySignedCompatiblePreviewResolutionDetailed(forged.wire, {
@@ -178,6 +186,12 @@ describe("compatible artifact transport", () => {
         expectedAuthority,
       }),
     ).resolves.toEqual({ ok: false, reason: "APPROVAL_EXPIRED" })
+    await expect(
+      verifySignedCompatiblePreviewResolutionDetailed(JSON.stringify(tamperedExpired), {
+        publicKey: trusted.publicKey,
+        expectedAuthority,
+      }),
+    ).resolves.toEqual({ ok: false, reason: "SIGNATURE_INVALID" })
     await expect(
       verifySignedCompatiblePreviewResolutionDetailed(JSON.stringify(swapped), {
         publicKey: trusted.publicKey,

--- a/lib/preview/__tests__/compatible-artifact.test.ts
+++ b/lib/preview/__tests__/compatible-artifact.test.ts
@@ -6,6 +6,7 @@ import {
   serializeSignedCompatiblePreviewResolution,
   signedCompatiblePreviewResolutionSchema,
   verifySignedCompatiblePreviewResolution,
+  verifySignedCompatiblePreviewResolutionDetailed,
 } from "../compatible-artifact"
 import { createSignedCompatibleFixture } from "./compatible-test-fixture"
 
@@ -151,6 +152,38 @@ describe("compatible artifact transport", () => {
         expectedAuthority,
       }),
     ).toBeNull()
+  })
+
+  it("reports fail-closed verification phases without exposing artifact contents", async () => {
+    const trusted = await createSignedCompatibleFixture()
+    const forged = await createSignedCompatibleFixture()
+    const expired = await createSignedCompatibleFixture({
+      issuedAt: Date.now() - 120_000,
+      expiresAt: Date.now() - 60_000,
+    })
+    const swapped = {
+      ...trusted.resolution,
+      artifact: { ...trusted.resolution.artifact, documentSource: "# Changed after approval" },
+    }
+
+    await expect(
+      verifySignedCompatiblePreviewResolutionDetailed(forged.wire, {
+        publicKey: trusted.publicKey,
+        expectedAuthority,
+      }),
+    ).resolves.toEqual({ ok: false, reason: "SIGNATURE_INVALID" })
+    await expect(
+      verifySignedCompatiblePreviewResolutionDetailed(expired.wire, {
+        publicKey: expired.publicKey,
+        expectedAuthority,
+      }),
+    ).resolves.toEqual({ ok: false, reason: "APPROVAL_EXPIRED" })
+    await expect(
+      verifySignedCompatiblePreviewResolutionDetailed(JSON.stringify(swapped), {
+        publicKey: trusted.publicKey,
+        expectedAuthority,
+      }),
+    ).resolves.toEqual({ ok: false, reason: "DIGEST_MISMATCH" })
   })
 
   it("rejects the constructed high-S twin of an otherwise valid raw P-256 signature before Web Crypto", async () => {

--- a/lib/preview/compatible-artifact.ts
+++ b/lib/preview/compatible-artifact.ts
@@ -103,6 +103,17 @@ export type VerifiedCompatiblePreviewResolution = SignedCompatiblePreviewResolut
   readonly [verifiedCompatibleResolutionBrand]: true
 }
 
+export type CompatiblePreviewVerificationFailureReason =
+  | "RESOLUTION_INVALID"
+  | "APPROVAL_EXPIRED"
+  | "CRYPTO_UNAVAILABLE"
+  | "SIGNATURE_INVALID"
+  | "DIGEST_MISMATCH"
+
+export type CompatiblePreviewVerificationResult =
+  | Readonly<{ ok: true; resolution: VerifiedCompatiblePreviewResolution }>
+  | Readonly<{ ok: false; reason: CompatiblePreviewVerificationFailureReason }>
+
 const verifiedCompatibleResolutions = new WeakSet<object>()
 
 const commandFields = {
@@ -462,14 +473,14 @@ function decodeSignature(input: string): Uint8Array | null {
   return decoded
 }
 
-export async function verifySignedCompatiblePreviewResolution(
+export async function verifySignedCompatiblePreviewResolutionDetailed(
   input: unknown,
   options: { publicKey: JsonWebKey; expectedAuthority: CompatiblePreviewAuthorityContext; now?: number },
-): Promise<VerifiedCompatiblePreviewResolution | null> {
+): Promise<CompatiblePreviewVerificationResult> {
   const preflight = preflightCompatibleResolutionWire(input, options.expectedAuthority)
-  if (!preflight) return null
+  if (!preflight) return { ok: false, reason: "RESOLUTION_INVALID" }
   const parsed = signedCompatiblePreviewResolutionSchema.safeParse(preflight)
-  if (!parsed.success) return null
+  if (!parsed.success) return { ok: false, reason: "RESOLUTION_INVALID" }
   const resolution = parsed.data
   const now = options.now ?? Date.now()
   if (
@@ -477,14 +488,15 @@ export async function verifySignedCompatiblePreviewResolution(
     now < 0 ||
     !authorityMatches(resolution.authority, options.expectedAuthority) ||
     resolution.authority.issuedAt > now + 30_000 ||
-    resolution.authority.expiresAt <= now ||
     resolution.authority.expiresAt <= resolution.authority.issuedAt ||
     resolution.authority.expiresAt - resolution.authority.issuedAt > 5 * 60_000
   ) {
-    return null
+    return { ok: false, reason: "RESOLUTION_INVALID" }
   }
+  if (resolution.authority.expiresAt <= now) return { ok: false, reason: "APPROVAL_EXPIRED" }
   const signature = decodeSignature(resolution.authority.signature)
-  if (!signature || !globalThis.crypto?.subtle) return null
+  if (!signature) return { ok: false, reason: "SIGNATURE_INVALID" }
+  if (!globalThis.crypto?.subtle) return { ok: false, reason: "CRYPTO_UNAVAILABLE" }
   try {
     const key = await globalThis.crypto.subtle.importKey(
       "jwk",
@@ -500,15 +512,28 @@ export async function verifySignedCompatiblePreviewResolution(
       signature as BufferSource,
       createCompatibleApprovalPayload({ authority, artifact: resolution.artifact }) as BufferSource,
     )
-    if (!valid) return null
-    const digest = await computeCompatibleExecutableDigest(parsed.data.artifact)
-    if (digest !== resolution.authority.executableDigest) return null
-    const verified = deepFreeze(resolution) as VerifiedCompatiblePreviewResolution
-    verifiedCompatibleResolutions.add(verified)
-    return verified
+    if (!valid) return { ok: false, reason: "SIGNATURE_INVALID" }
   } catch {
-    return null
+    return { ok: false, reason: "SIGNATURE_INVALID" }
   }
+  let digest: string
+  try {
+    digest = await computeCompatibleExecutableDigest(parsed.data.artifact)
+  } catch {
+    return { ok: false, reason: "CRYPTO_UNAVAILABLE" }
+  }
+  if (digest !== resolution.authority.executableDigest) return { ok: false, reason: "DIGEST_MISMATCH" }
+  const verified = deepFreeze(resolution) as VerifiedCompatiblePreviewResolution
+  verifiedCompatibleResolutions.add(verified)
+  return { ok: true, resolution: verified }
+}
+
+export async function verifySignedCompatiblePreviewResolution(
+  input: unknown,
+  options: { publicKey: JsonWebKey; expectedAuthority: CompatiblePreviewAuthorityContext; now?: number },
+): Promise<VerifiedCompatiblePreviewResolution | null> {
+  const result = await verifySignedCompatiblePreviewResolutionDetailed(input, options)
+  return result.ok ? result.resolution : null
 }
 
 export async function verifyCompatibleExecutableDigest(

--- a/lib/preview/compatible-artifact.ts
+++ b/lib/preview/compatible-artifact.ts
@@ -493,7 +493,6 @@ export async function verifySignedCompatiblePreviewResolutionDetailed(
   ) {
     return { ok: false, reason: "RESOLUTION_INVALID" }
   }
-  if (resolution.authority.expiresAt <= now) return { ok: false, reason: "APPROVAL_EXPIRED" }
   const signature = decodeSignature(resolution.authority.signature)
   if (!signature) return { ok: false, reason: "SIGNATURE_INVALID" }
   if (!globalThis.crypto?.subtle) return { ok: false, reason: "CRYPTO_UNAVAILABLE" }
@@ -523,6 +522,7 @@ export async function verifySignedCompatiblePreviewResolutionDetailed(
     return { ok: false, reason: "CRYPTO_UNAVAILABLE" }
   }
   if (digest !== resolution.authority.executableDigest) return { ok: false, reason: "DIGEST_MISMATCH" }
+  if (resolution.authority.expiresAt <= now) return { ok: false, reason: "APPROVAL_EXPIRED" }
   const verified = deepFreeze(resolution) as VerifiedCompatiblePreviewResolution
   verifiedCompatibleResolutions.add(verified)
   return { ok: true, resolution: verified }


### PR DESCRIPTION
## Summary
- preserve the fail-closed compatible artifact verifier while returning bounded internal failure phases
- show actionable Studio diagnostics for invalid, expired, unavailable, forged, or digest-mismatched approvals
- add regression coverage for signature, expiry, digest, and UI fallback behavior

## Verification
- 154 test files / 1796 tests pass
- TypeScript clean
- Biome clean on changed files
- git diff --check clean