### PR TITLE
Render compatible void elements without children

### DIFF
--- a/components/preview-sandbox/__tests__/compatible-render-tree.test.tsx
+++ b/components/preview-sandbox/__tests__/compatible-render-tree.test.tsx
@@ -89,6 +89,17 @@ describe("compatible inert render tree", () => {
     expect(sanitizeCompatibleRenderTree([{ kind: "text", value: "x".repeat(300_000) }])).toBeNull()
   })
 
+  it("renders approved void elements without passing a React children argument", () => {
+    const tree = sanitizeCompatibleRenderTree([
+      { kind: "element", tag: "hr", props: {}, children: [] },
+      { kind: "element", tag: "br", props: {}, children: [] },
+    ])
+
+    const { container } = render(<CompatibleRenderTreeView tree={tree ?? []} />)
+    expect(container.querySelectorAll("hr")).toHaveLength(1)
+    expect(container.querySelectorAll("br")).toHaveLength(1)
+  })
+
   it("scopes portable primitive styles without restoring navigation or media behavior", () => {
     const tree = sanitizeCompatibleRenderTree([
       {

--- a/components/preview-sandbox/compatible-render-tree.tsx
+++ b/components/preview-sandbox/compatible-render-tree.tsx
@@ -48,6 +48,7 @@ const ALLOWED_TAGS = new Set([
   "tr",
   "ul",
 ])
+const VOID_TAGS = new Set(["br", "hr"])
 
 const DROP_CONTENT_TAGS = new Set([
   "audio",
@@ -274,6 +275,7 @@ export function sanitizeCompatibleRenderTree(input: unknown): CompatibleRenderTr
 function renderNode(node: CompatibleRenderNode, key: string): React.ReactNode {
   if (node.kind === "text") return node.value
   if (!ALLOWED_TAGS.has(node.tag)) return null
+  if (VOID_TAGS.has(node.tag)) return React.createElement(node.tag, { ...node.props, key })
   return React.createElement(
     node.tag,
     { ...node.props, key },


### PR DESCRIPTION
## Summary
- render approved void elements without a React children argument
- cover both hr and br with a React 19 regression test

## Production reproduction
Merry Magic Mail's real MDX adapter produced a valid static-inert tree containing an hr. The compatible sandbox passed an empty children array to React.createElement for that void element, and React 19 rejected the tree with: `hr is a void element tag and must neither have children nor use dangerouslySetInnerHTML`.

## Verification
- targeted compatible sandbox tests: 3 files / 17 tests
- full suite: 154 files / 1797 tests
- TypeScript clean
- Biome clean on changed files
- git diff --check clean