### PR TITLE
Retry component edit identity after hydration

### DIFF
--- a/components/studio/__tests__/component-edit-flow.test.tsx
+++ b/components/studio/__tests__/component-edit-flow.test.tsx
@@ -45,6 +45,28 @@ function renderEditor(source: string, occurrence = 0, mdastSource = source) {
 afterEach(cleanup)
 
 describe("position-bound Studio component editing", () => {
+  it("retries identity capture after the editor source finishes hydrating", () => {
+    const source = '<Callout title="Hydrated" variant="accent">Body</Callout>'
+    let currentSource = ""
+    const catalog = officialCatalog()
+    const adapter = createStudioAdapterState({ authoringCatalog: catalog, nativeComponentNames: [] })
+    const renderTree = () => (
+      <StudioAdapterProvider value={adapter}>
+        <ComponentEditProvider authoringCatalog={catalog} getSource={() => currentSource} applySource={vi.fn()}>
+          <GenericJsxEditor mdastNode={nodeAt(source) as never} descriptor={{ name: "Callout" } as never} />
+        </ComponentEditProvider>
+      </StudioAdapterProvider>
+    )
+
+    const view = render(renderTree())
+    expect(screen.getByRole("button", { name: "Edit Callout" })).toBeDisabled()
+
+    currentSource = source
+    view.rerender(renderTree())
+
+    expect(screen.getByRole("button", { name: "Edit Callout" })).toBeEnabled()
+  })
+
   it("edits one clicked Callout prop while preserving all unrelated source bytes", async () => {
     const source = [
       "import { Callout } from './callout'",

--- a/components/studio/jsx-component-descriptors.tsx
+++ b/components/studio/jsx-component-descriptors.tsx
@@ -11,7 +11,7 @@ export function GenericJsxEditor({ descriptor, mdastNode }: JsxEditorProps) {
   const name = typeof mdastNode.name === "string" ? mdastNode.name : descriptor.name
   const start = mdastNode.position?.start.offset
   const identityRef = React.useRef<MdxComponentEditIdentity | null | undefined>(undefined)
-  if (identityRef.current === undefined && editBridge && typeof name === "string" && Number.isSafeInteger(start)) {
+  if (identityRef.current == null && editBridge && typeof name === "string" && Number.isSafeInteger(start)) {
     identityRef.current = editBridge.captureIdentity({ name, start: start as number })
   }
   const canRequestEdit = editBridge !== null && identityRef.current != null


### PR DESCRIPTION
## Summary
- retry a component's bounded identity capture when the first render occurs before editor source hydration
- retain the shared source/index cache, so retries do not multiply parsing work for one source snapshot
- add a red-green regression for the production E2E lifecycle

## Production evidence
Merry Magic Mail loaded all five authoring definitions and the Insert palette, but existing component Edit controls stayed disabled because a transient null identity was permanently cached in the rendered component.

## Verification
- regression captured RED before the implementation
- focused component edit/descriptors: 11 tests green
- full suite: 154 files / 1798 tests green
- TypeScript clean
- Biome and git diff check clean