### PR TITLE
Capture component identity from the loaded source

### DIFF
--- a/components/studio/__tests__/component-edit-flow.test.tsx
+++ b/components/studio/__tests__/component-edit-flow.test.tsx
@@ -45,6 +45,27 @@ function renderEditor(source: string, occurrence = 0, mdastSource = source) {
 afterEach(cleanup)
 
 describe("position-bound Studio component editing", () => {
+  it("captures identities from the loaded source snapshot before the editor ref hydrates", () => {
+    const source = '<Callout title="Loaded" variant="accent">Body</Callout>'
+    const catalog = officialCatalog()
+    const adapter = createStudioAdapterState({ authoringCatalog: catalog, nativeComponentNames: [] })
+
+    render(
+      <StudioAdapterProvider value={adapter}>
+        <ComponentEditProvider
+          authoringCatalog={catalog}
+          identitySource={source}
+          getSource={() => ""}
+          applySource={vi.fn()}
+        >
+          <GenericJsxEditor mdastNode={nodeAt(source) as never} descriptor={{ name: "Callout" } as never} />
+        </ComponentEditProvider>
+      </StudioAdapterProvider>,
+    )
+
+    expect(screen.getByRole("button", { name: "Edit Callout" })).toBeEnabled()
+  })
+
   it("retries identity capture after the editor source finishes hydrating", () => {
     const source = '<Callout title="Hydrated" variant="accent">Body</Callout>'
     let currentSource = ""

--- a/components/studio/component-edit-context.tsx
+++ b/components/studio/component-edit-context.tsx
@@ -28,11 +28,13 @@ type EditSession = Readonly<{ component: AuthoringComponent; prepared: PreparedC
 
 export function ComponentEditProvider({
   authoringCatalog,
+  identitySource,
   getSource,
   applySource,
   children,
 }: {
   authoringCatalog: AuthoringCatalog
+  identitySource?: string
   getSource: () => string
   applySource: (source: string) => void
   children: React.ReactNode
@@ -65,7 +67,7 @@ export function ComponentEditProvider({
 
   const captureIdentity = React.useCallback(
     (position: ComponentEditPosition): MdxComponentEditIdentity | null => {
-      const source = getSource()
+      const source = identitySource ?? getSource()
       if (identityIndexCache.current?.source !== source) {
         identityIndexCache.current = { source, index: buildComponentEditIdentityIndex(source) }
       }
@@ -73,7 +75,7 @@ export function ComponentEditProvider({
       const captured = index.ok ? index.capture(position) : index
       return captured.ok ? captured.identity : null
     },
-    [getSource],
+    [getSource, identitySource],
   )
 
   const editBridge = React.useMemo<ComponentEditBridge>(

--- a/components/studio/editor.tsx
+++ b/components/studio/editor.tsx
@@ -332,6 +332,7 @@ export function Editor({
     <StudioAdapterProvider value={editorProviderState}>
       <ComponentEditProvider
         authoringCatalog={authoringCatalog}
+        identitySource={sanitizedContent}
         getSource={getEditSource}
         applySource={applyEditedSource}
       >


### PR DESCRIPTION
## Summary
- capture rendered component identities from the immutable loaded source snapshot instead of a not-yet-hydrated editor ref
- keep edit-open and mutation validation against the latest editor source
- cover the deep-link hydration lifecycle with a red-green regression

## Production evidence
The standard Merry Studio URL became editable after PR #54, but the catch-all deep link could settle without a later rerender and leave Edit controls disabled. The document and compatible preview were otherwise fully loaded.

## Verification
- regression captured RED before implementation
- focused component editing: 12 tests green
- full suite: 154 files / 1799 tests green
- TypeScript clean
- Biome and git diff check clean