### PR TITLE
Keep component editing safe when MDX positions are absent

### DIFF
--- a/components/studio/__tests__/component-edit-flow.test.tsx
+++ b/components/studio/__tests__/component-edit-flow.test.tsx
@@ -45,6 +45,74 @@ function renderEditor(source: string, occurrence = 0, mdastSource = source) {
 afterEach(cleanup)
 
 describe("position-bound Studio component editing", () => {
+  it("keeps a uniquely attributed component editable when MDXEditor drops source positions", async () => {
+    const source = '<Callout title="First" variant="accent" />\n\n<Callout title="Second" variant="accent" />'
+    const catalog = officialCatalog()
+    const adapter = createStudioAdapterState({ authoringCatalog: catalog, nativeComponentNames: [] })
+
+    render(
+      <StudioAdapterProvider value={adapter}>
+        <ComponentEditProvider
+          authoringCatalog={catalog}
+          identitySource={source}
+          getSource={() => source}
+          applySource={vi.fn()}
+        >
+          <GenericJsxEditor
+            mdastNode={
+              {
+                type: "mdxJsxFlowElement",
+                name: "Callout",
+                attributes: [
+                  { type: "mdxJsxAttribute", name: "title", value: "Second" },
+                  { type: "mdxJsxAttribute", name: "variant", value: "accent" },
+                ],
+              } as never
+            }
+            descriptor={{ name: "Callout" } as never}
+          />
+        </ComponentEditProvider>
+      </StudioAdapterProvider>,
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit Callout" }))
+    expect(await screen.findByLabelText("Title")).toHaveValue("Second")
+  })
+
+  it("refuses a positionless identity when the latest source makes it ambiguous", () => {
+    const loadedSource = '<Callout title="Same" variant="accent">One</Callout>'
+    const latestSource = `${loadedSource}\n\n<Callout title="Same" variant="accent">Two</Callout>`
+    const catalog = officialCatalog()
+    const adapter = createStudioAdapterState({ authoringCatalog: catalog, nativeComponentNames: [] })
+
+    render(
+      <StudioAdapterProvider value={adapter}>
+        <ComponentEditProvider
+          authoringCatalog={catalog}
+          identitySource={loadedSource}
+          getSource={() => latestSource}
+          applySource={vi.fn()}
+        >
+          <GenericJsxEditor
+            mdastNode={
+              {
+                type: "mdxJsxTextElement",
+                name: "Callout",
+                attributes: [
+                  { type: "mdxJsxAttribute", name: "title", value: "Same" },
+                  { type: "mdxJsxAttribute", name: "variant", value: "accent" },
+                ],
+              } as never
+            }
+            descriptor={{ name: "Callout" } as never}
+          />
+        </ComponentEditProvider>
+      </StudioAdapterProvider>,
+    )
+
+    expect(screen.getByRole("button", { name: "Edit Callout" })).toBeDisabled()
+  })
+
   it("captures identities from the loaded source snapshot before the editor ref hydrates", () => {
     const source = '<Callout title="Loaded" variant="accent">Body</Callout>'
     const catalog = officialCatalog()

--- a/components/studio/component-edit-context.tsx
+++ b/components/studio/component-edit-context.tsx
@@ -11,7 +11,12 @@ import {
 } from "@/lib/studio/mdx-source-edit"
 import { ComponentEditModal } from "./component-edit-modal"
 
-type ComponentEditPosition = Readonly<{ name: string; start: number }>
+type ComponentEditPosition = Readonly<{
+  name: string
+  kind: "flow" | "text"
+  start?: number
+  attributes: unknown
+}>
 type ComponentEditRequest = (identity: MdxComponentEditIdentity) => void
 type ComponentEditBridge = Readonly<{
   captureIdentity: (position: ComponentEditPosition) => MdxComponentEditIdentity | null
@@ -67,7 +72,9 @@ export function ComponentEditProvider({
 
   const captureIdentity = React.useCallback(
     (position: ComponentEditPosition): MdxComponentEditIdentity | null => {
-      const source = identitySource ?? getSource()
+      // Source offsets belong to the loaded snapshot, while a positionless
+      // MDXEditor node must be resolved only against its latest serialized source.
+      const source = position.start === undefined ? getSource() : (identitySource ?? getSource())
       if (identityIndexCache.current?.source !== source) {
         identityIndexCache.current = { source, index: buildComponentEditIdentityIndex(source) }
       }

--- a/components/studio/jsx-component-descriptors.tsx
+++ b/components/studio/jsx-component-descriptors.tsx
@@ -10,9 +10,15 @@ export function GenericJsxEditor({ descriptor, mdastNode }: JsxEditorProps) {
   const editBridge = useComponentEditRequest()
   const name = typeof mdastNode.name === "string" ? mdastNode.name : descriptor.name
   const start = mdastNode.position?.start.offset
+  const kind = mdastNode.type === "mdxJsxTextElement" ? "text" : "flow"
   const identityRef = React.useRef<MdxComponentEditIdentity | null | undefined>(undefined)
-  if (identityRef.current == null && editBridge && typeof name === "string" && Number.isSafeInteger(start)) {
-    identityRef.current = editBridge.captureIdentity({ name, start: start as number })
+  if (identityRef.current == null && editBridge && typeof name === "string") {
+    identityRef.current = editBridge.captureIdentity({
+      name,
+      kind,
+      ...(Number.isSafeInteger(start) ? { start: start as number } : {}),
+      attributes: mdastNode.attributes,
+    })
   }
   const canRequestEdit = editBridge !== null && identityRef.current != null
   return (

--- a/lib/studio/__tests__/mdx-source-edit.test.ts
+++ b/lib/studio/__tests__/mdx-source-edit.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest"
 import { buildAuthoringCatalog } from "../authoring-catalog"
-import { editComponentProp, findEditableMdxComponents, prepareComponentPropEdit } from "../mdx-source-edit"
+import {
+  buildComponentEditIdentityIndex,
+  editComponentProp,
+  findEditableMdxComponents,
+  prepareComponentPropEdit,
+} from "../mdx-source-edit"
 
 function targetFor(source: string, name: string, occurrence = 0) {
   const discovered = findEditableMdxComponents(source)
@@ -12,6 +17,79 @@ function targetFor(source: string, name: string, occurrence = 0) {
 }
 
 describe("source-preserving MDX component prop edits", () => {
+  it("captures a positionless rendered node by unique literal attributes", () => {
+    const source = '<Callout title="First" variant="accent" />\n\n<Callout title="Second" variant="accent" />'
+    const index = buildComponentEditIdentityIndex(source)
+    expect(index.ok).toBe(true)
+    if (!index.ok) throw new Error("expected identity index")
+
+    expect(
+      index.capture({
+        name: "Callout",
+        kind: "flow",
+        attributes: [
+          { type: "mdxJsxAttribute", name: "variant", value: "accent" },
+          { type: "mdxJsxAttribute", name: "title", value: "Second" },
+        ],
+      }),
+    ).toMatchObject({ ok: true, identity: { name: "Callout", openingTag: expect.stringContaining("Second") } })
+  })
+
+  it("fails closed when a positionless structural identity is still ambiguous", () => {
+    const source = '<Callout variant="accent" />\n\n<Callout variant="accent" />'
+    const index = buildComponentEditIdentityIndex(source)
+    expect(index.ok).toBe(true)
+    if (!index.ok) throw new Error("expected identity index")
+
+    expect(
+      index.capture({
+        name: "Callout",
+        kind: "flow",
+        attributes: [{ type: "mdxJsxAttribute", name: "variant", value: "accent" }],
+      }),
+    ).toEqual({ ok: false, source, code: "UNSAFE_TO_PRESERVE" })
+  })
+
+  it("rejects wrong-kind and non-canonical positionless anchors", () => {
+    const source = '<Callout title="Safe" />'
+    const index = buildComponentEditIdentityIndex(source)
+    expect(index.ok).toBe(true)
+    if (!index.ok) throw new Error("expected identity index")
+    const attributes = [{ type: "mdxJsxAttribute", name: "title", value: "Safe" }]
+
+    expect(index.capture({ name: "Callout", kind: "text", attributes })).toEqual({
+      ok: false,
+      source,
+      code: "UNSAFE_TO_PRESERVE",
+    })
+    expect(
+      index.capture({
+        name: "Callout",
+        kind: "flow",
+        attributes: [
+          {
+            type: "mdxJsxAttribute",
+            name: "title",
+            value: { type: "mdxJsxAttributeValueExpression", value: "computeTitle()" },
+          },
+        ],
+      }),
+    ).toEqual({ ok: false, source, code: "UNSAFE_TO_PRESERVE" })
+
+    const accessorAttribute = Object.create(null)
+    Object.defineProperty(accessorAttribute, "type", {
+      enumerable: true,
+      get: () => {
+        throw new Error("must not execute")
+      },
+    })
+    expect(index.capture({ name: "Callout", kind: "flow", attributes: [accessorAttribute] })).toEqual({
+      ok: false,
+      source,
+      code: "UNSAFE_TO_PRESERVE",
+    })
+  })
+
   it("prepares one exact position-bound literal component without confusing duplicates", () => {
     const source = '<Callout title="First" />\n<Callout title="Second" variant="accent">Body</Callout>'
     const def = buildAuthoringCatalog({

--- a/lib/studio/mdx-source-edit.ts
+++ b/lib/studio/mdx-source-edit.ts
@@ -67,6 +67,47 @@ type MdxAttribute = {
   value?: string | null | { type?: string; value?: string }
 }
 type MdxElement = RepoPressMdxSyntaxNode & { position?: OffsetPosition; attributes?: MdxAttribute[] }
+const ATTRIBUTE_IDENTITY = Symbol("attributeIdentity")
+type IndexedMdxComponentEditTarget = MdxComponentEditTarget & {
+  readonly [ATTRIBUTE_IDENTITY]: string | null
+}
+
+function literalAttributeIdentity(attributes: unknown): string | null {
+  try {
+    if (
+      !Array.isArray(attributes) ||
+      Object.getPrototypeOf(attributes) !== Array.prototype ||
+      attributes.length > 128
+    ) {
+      return null
+    }
+    const normalized: Array<readonly [string, string, string]> = []
+    const names = new Set<string>()
+    for (let index = 0; index < attributes.length; index += 1) {
+      const attribute = dataValue(attributes, String(index))
+      if (!isPlainDataRecord(attribute) || dataValue(attribute, "type") !== "mdxJsxAttribute") return null
+      const name = dataValue(attribute, "name")
+      const value = dataValue(attribute, "value")
+      if (typeof name !== "string" || names.has(name)) return null
+      assertSafeAuthoringPropName(name)
+      names.add(name)
+      if (value === null) normalized.push([name, "boolean", "true"])
+      else if (typeof value === "string") normalized.push([name, "string", value])
+      else if (isPlainDataRecord(value) && dataValue(value, "type") === "mdxJsxAttributeValueExpression") {
+        const expression = dataValue(value, "value")
+        if (typeof expression !== "string") return null
+        const literal = expression.trim()
+        if (/^(?:true|false)$/.test(literal)) normalized.push([name, "boolean", literal])
+        else if (/^-?(?:0|[1-9]\d*)(?:\.\d+)?$/.test(literal)) normalized.push([name, "number", literal])
+        else return null
+      } else return null
+    }
+    normalized.sort(([left], [right]) => left.localeCompare(right))
+    return JSON.stringify(normalized)
+  } catch {
+    return null
+  }
+}
 
 const refuse = (source: string): MdxSourceEditRefusal => ({ ok: false, source, code: "UNSAFE_TO_PRESERVE" })
 
@@ -106,8 +147,8 @@ function openingTagFor(source: string, node: MdxElement): { start: number; end: 
   return { start: safeStart, end, source: source.slice(safeStart, end) }
 }
 
-function collectTargets(source: string, root: RepoPressMdxSyntaxNode): readonly MdxComponentEditTarget[] | null {
-  const targets: MdxComponentEditTarget[] = []
+function collectTargets(source: string, root: RepoPressMdxSyntaxNode): readonly IndexedMdxComponentEditTarget[] | null {
+  const targets: IndexedMdxComponentEditTarget[] = []
   const stack: Array<{ node: RepoPressMdxSyntaxNode; path: number[] }> = [{ node: root, path: [] }]
   while (stack.length > 0) {
     const entry = stack.pop()
@@ -145,6 +186,7 @@ function collectTargets(source: string, root: RepoPressMdxSyntaxNode): readonly 
             nodeSource: source.slice(opening.start, nodeEnd as number),
             nodeEnd: nodeEnd as number,
             sourceSnapshot: source,
+            [ATTRIBUTE_IDENTITY]: literalAttributeIdentity(node.attributes ?? []),
           }),
         )
       }
@@ -163,7 +205,15 @@ export function findEditableMdxComponents(source: string): FindEditableMdxCompon
   const parsed = parseRepoPressMdxSyntax(source)
   if (!parsed.ok) return refuse(source)
   const targets = collectTargets(source, parsed.root)
-  return targets ? { ok: true, targets } : refuse(source)
+  return targets
+    ? {
+        ok: true,
+        targets: targets.map((target) => {
+          const { [ATTRIBUTE_IDENTITY]: _attributeIdentity, ...publicTarget } = target
+          return Object.freeze(publicTarget)
+        }),
+      }
+    : refuse(source)
 }
 
 function normalizeTarget(target: unknown): MdxComponentEditTarget | null {
@@ -277,6 +327,22 @@ function normalizePositionAnchor(anchor: unknown): { name: string; start: number
   }
 }
 
+function normalizeStructuralAnchor(
+  anchor: unknown,
+): { name: string; kind: "flow" | "text"; attributeIdentity: string | null } | null {
+  try {
+    if (!isPlainDataRecord(anchor)) return null
+    const name = dataValue(anchor, "name")
+    const kind = dataValue(anchor, "kind")
+    const attributes = dataValue(anchor, "attributes")
+    if (typeof name !== "string" || (kind !== "flow" && kind !== "text")) return null
+    assertSafeMdxName(name)
+    return { name, kind, attributeIdentity: literalAttributeIdentity(attributes) }
+  } catch {
+    return null
+  }
+}
+
 function normalizeEditIdentity(identity: unknown): MdxComponentEditIdentity | null {
   try {
     if (!isPlainDataRecord(identity)) return null
@@ -333,16 +399,28 @@ function resolveEditAnchorStart(source: string, anchor: Readonly<{ name: string;
 /** Capture a bounded source identity for one exact rendered MDAST component. */
 function captureIdentityFromTargets(
   source: string,
-  targets: readonly MdxComponentEditTarget[],
+  targets: readonly IndexedMdxComponentEditTarget[],
   anchor: unknown,
 ): CaptureComponentEditIdentityResult {
   const normalizedAnchor = normalizePositionAnchor(anchor)
-  if (!normalizedAnchor) return refuse(source)
-  const coordinateCandidates = new Set<number>([normalizedAnchor.start])
-  coordinateCandidates.add(normalizedAnchor.start + (source.length - source.trimStart().length))
-  const matches = targets.filter(
-    (target) => target.name === normalizedAnchor.name && coordinateCandidates.has(target.start),
-  )
+  let matches: readonly IndexedMdxComponentEditTarget[] = []
+  if (normalizedAnchor) {
+    const coordinateCandidates = new Set<number>([normalizedAnchor.start])
+    coordinateCandidates.add(normalizedAnchor.start + (source.length - source.trimStart().length))
+    matches = targets.filter(
+      (target) => target.name === normalizedAnchor.name && coordinateCandidates.has(target.start),
+    )
+  }
+  if (matches.length !== 1) {
+    const structuralAnchor = normalizeStructuralAnchor(anchor)
+    if (!structuralAnchor || structuralAnchor.attributeIdentity === null) return refuse(source)
+    matches = targets.filter(
+      (target) =>
+        target.name === structuralAnchor.name &&
+        target.kind === structuralAnchor.kind &&
+        target[ATTRIBUTE_IDENTITY] === structuralAnchor.attributeIdentity,
+    )
+  }
   if (matches.length !== 1 || !isWithinIdentityBudget(matches[0].openingTag, matches[0].nodeSource)) {
     return refuse(source)
   }


### PR DESCRIPTION
## Summary
- retain exact position capture when MDXEditor provides source offsets
- add a fail-closed structural fallback for positionless JSX nodes: unique component names, or a unique bounded literal-attribute identity
- preserve exact full-node/opening-tag identity and latest-source revalidation before editing or mutation
- keep ambiguous duplicates disabled

## Production evidence
After browser history and rich/source round-trips, MDXEditor can retain a valid JSX node while dropping its source position. The Merry compatible preview remained correct, but every existing component Edit control became disabled.

## Verification
- red-green coverage for a positionless duplicate selected by literal attributes
- explicit ambiguous-duplicate refusal coverage
- focused source/edit suite: 38 tests green
- full suite: 154 files / 1802 tests green
- TypeScript clean
- Biome and git diff check clean