### PR TITLE
docs: align production domain guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,13 @@ openssl rand -base64 32
 npx convex env set REPOPRESS_CAPABILITY_SECRET <generated-value>
 ```
 
+The command above configures the development deployment selected by
+`npx convex dev`. For production, target the production deployment explicitly:
+
+```bash
+npx convex env set --prod REPOPRESS_CAPABILITY_SECRET <generated-value>
+```
+
 ```dotenv
 REPOPRESS_CAPABILITY_SECRET=<same-generated-value>
 ```

--- a/docs/plans/2026-08-02-production-hardening-design.md
+++ b/docs/plans/2026-08-02-production-hardening-design.md
@@ -24,7 +24,7 @@ Messages remain calm and specific: the workspace could not open, saved GitHub co
 
 Treat `signIn.social` as a result-bearing API. A returned Better Auth error becomes a visible destructive alert, thrown/network failures use a generic retry message, and successful results retain the requested safe in-app callback. Loading state always settles and duplicate submission remains disabled.
 
-Production Convex receives `SITE_URL=https://repo-press-itsyogesh.vercel.app`. Auth startup validates that value as a single application origin and uses it for Better Auth's `baseURL`, explicit `trustedOrigins`, and the GitHub provider's explicit `/api/auth/callback/github` redirect. This keeps both the sign-in request and callback on the application origin so the application domain receives the state and session cookies.
+Production Convex receives `SITE_URL=https://repo-press.vercel.app`. Auth startup validates that value as a single application origin and uses it for Better Auth's `baseURL`, explicit `trustedOrigins`, and the GitHub provider's explicit `/api/auth/callback/github` redirect. This keeps both the sign-in request and callback on the application origin so the application domain receives the state and session cookies.
 
 ### Capability configuration
 

--- a/docs/plans/2026-08-02-production-hardening.md
+++ b/docs/plans/2026-08-02-production-hardening.md
@@ -154,7 +154,13 @@ Commit message, only if needed: `test: close production hardening regressions`
 
 **Step 1: Configure Convex auth origin**
 
-Set production Convex `SITE_URL` to `https://repo-press-itsyogesh.vercel.app`. Retain the existing production capability secret.
+Set production Convex `SITE_URL` to `https://repo-press.vercel.app` with an explicit production target:
+
+```bash
+npx convex env set --prod SITE_URL https://repo-press.vercel.app
+```
+
+Retain the existing production capability secret.
 
 **Step 2: Generate preview signing material**
 
@@ -174,7 +180,7 @@ Set production Vercel:
 Create a dedicated Vercel project from the reviewed branch with:
 
 - `REPOPRESS_DEPLOYMENT_ROLE=sandbox`;
-- `NEXT_PUBLIC_APP_URL=https://repo-press-itsyogesh.vercel.app` for CSP `frame-ancestors`;
+- `NEXT_PUBLIC_APP_URL=https://repo-press.vercel.app` for CSP `frame-ancestors`;
 - the public production `NEXT_PUBLIC_CONVEX_URL` and `NEXT_PUBLIC_CONVEX_SITE_URL` required by the shared build;
 - the matching `NEXT_PUBLIC_PREVIEW_APPROVAL_PUBLIC_KEY_JWK`.
 


### PR DESCRIPTION
## Summary
- replace the obsolete production hostname with the canonical repo-press.vercel.app origin
- document the explicit Convex --prod flag for production environment updates

## Verification
- git diff --check
- repository-wide search confirms the obsolete hostname is gone from tracked guidance