### PR TITLE
Fix production preview recovery and article titles

### DIFF
--- a/components/studio/hooks/__tests__/use-studio-queries-paths.test.tsx
+++ b/components/studio/hooks/__tests__/use-studio-queries-paths.test.tsx
@@ -194,6 +194,53 @@ describe("useStudioQueries path ingress", () => {
     expect(result!.titleMap).toEqual({ "content/docs/guides/start.mdx": "Start" })
   })
 
+  it("prefers a saved legacy draft over a canonical title-only placeholder", () => {
+    useQueryMock
+      .mockReturnValueOnce({ _id: "user_1" })
+      .mockReturnValueOnce({ _id: "project_123" })
+      .mockReturnValueOnce({
+        _id: "doc_placeholder",
+        filePath: "guides/start.mdx",
+        pathRepresentation: "content_relative_v1",
+        title: "Start",
+        status: "draft",
+        updatedAt: 1,
+      })
+      .mockReturnValueOnce({
+        _id: "doc_saved_draft",
+        filePath: "content/docs/guides/start.mdx",
+        title: "Draft title",
+        status: "draft",
+        body: "# Saved draft",
+        frontmatter: { title: "Draft title" },
+        updatedAt: 2,
+      })
+      .mockReturnValueOnce([])
+      .mockReturnValueOnce([])
+      .mockReturnValueOnce([])
+      .mockReturnValueOnce(null)
+      .mockReturnValueOnce(null)
+      .mockReturnValueOnce([])
+      .mockReturnValueOnce([])
+
+    let result: ReturnType<typeof useStudioQueries> | null = null
+    function Harness() {
+      result = useStudioQueries("content/docs/guides/start.mdx")
+      return null
+    }
+
+    renderToStaticMarkup(<Harness />)
+
+    expect(result!.document).toEqual(
+      expect.objectContaining({
+        _id: "doc_saved_draft",
+        filePath: "guides/start.mdx",
+        body: "# Saved draft",
+        frontmatter: { title: "Draft title" },
+      }),
+    )
+  })
+
   it("looks up untagged legacy documents when the content root is empty", () => {
     studioContextMock.contentRoot = ""
     useQueryMock

--- a/components/studio/hooks/use-studio-queries.ts
+++ b/components/studio/hooks/use-studio-queries.ts
@@ -266,7 +266,11 @@ export function useStudioQueries(
   const document = React.useMemo(() => {
     if (canonicalDocument === undefined) return undefined
     if (!canonicalDocument && shouldLookupLegacyDocument && legacyDocument === undefined) return undefined
-    const storedDocument = canonicalDocument ?? legacyDocument
+    const canonicalHasDraft =
+      canonicalDocument && (typeof canonicalDocument.body === "string" || canonicalDocument.frontmatter !== undefined)
+    const legacyHasDraft =
+      legacyDocument && (typeof legacyDocument.body === "string" || legacyDocument.frontmatter !== undefined)
+    const storedDocument = !canonicalHasDraft && legacyHasDraft ? legacyDocument : (canonicalDocument ?? legacyDocument)
     if (!storedDocument) return storedDocument
     return {
       ...storedDocument,

--- a/convex/documents.ts
+++ b/convex/documents.ts
@@ -61,10 +61,14 @@ function normalizeBoundedTitle(value: string): string | null {
   return title
 }
 
-function titleFromContent(filePath: string, content: string): string {
+function fallbackTitleFromPath(filePath: string): string {
   const fileName = filePath.split("/").pop() ?? filePath
   const fileNameStem = fileName.replace(/\.(mdx?|markdown)$/i, "")
-  const fallbackTitle = normalizeBoundedTitle(fileNameStem) ?? "Untitled"
+  return normalizeBoundedTitle(fileNameStem) ?? "Untitled"
+}
+
+function titleFromContent(filePath: string, content: string): string {
+  const fallbackTitle = fallbackTitleFromPath(filePath)
   const parsedTitle = parseContentFile(content, filePath).metadata.title
   if (typeof parsedTitle !== "string") return fallbackTitle
   return normalizeBoundedTitle(parsedTitle) ?? fallbackTitle
@@ -444,6 +448,17 @@ export const getOrCreateTitleSyncBatchInternal = internalMutation({
         .first()
       if (found) {
         existing += 1
+        if (
+          found.body === undefined &&
+          found.frontmatter === undefined &&
+          (found.title !== document.title || found.githubSha !== document.githubSha)
+        ) {
+          await ctx.db.patch(found._id, {
+            title: document.title,
+            githubSha: document.githubSha,
+            updatedAt: Date.now(),
+          })
+        }
         continue
       }
 
@@ -1070,25 +1085,33 @@ export const syncTreeTitles = action({
     const existingDocs = await ctx.runQuery(internal.documents.listByProjectInternal, {
       projectId: args.projectId,
     })
-    const existingPaths = new Set(
+    const existingByPath = new Map(
       existingDocs.flatMap((document) => {
         const contentPath = tryResolveStoredContentPath(
           project.contentRoot,
           document.filePath,
           document.pathRepresentation as StoredPathRepresentation | undefined,
         )
-        return contentPath ? [contentPath] : []
+        return contentPath ? [[contentPath, document] as const] : []
       }),
     )
 
-    const missingFiles = files.filter((f) => !existingPaths.has(f.path))
-    if (missingFiles.length === 0) return
+    const filesToSync = files.filter((file) => {
+      const existing = existingByPath.get(file.path)
+      if (!existing) return true
+      const isGitBackedPlaceholder =
+        existing.body === undefined &&
+        existing.frontmatter === undefined &&
+        (existing.githubSha !== file.sha || existing.title === fallbackTitleFromPath(file.path))
+      return isGitBackedPlaceholder
+    })
+    if (filesToSync.length === 0) return
 
     // Fetch and validate every missing file before opening the single write transaction.
     const BATCH_SIZE = 5
     const normalizedDocuments: NormalizedTitleSyncDocument[] = []
-    for (let i = 0; i < missingFiles.length; i += BATCH_SIZE) {
-      const batch = missingFiles.slice(i, i + BATCH_SIZE)
+    for (let i = 0; i < filesToSync.length; i += BATCH_SIZE) {
+      const batch = filesToSync.slice(i, i + BATCH_SIZE)
       const normalizedBatch = await Promise.all(
         batch.map(async (file) => {
           let response: Response

--- a/lib/__tests__/content-metadata.test.ts
+++ b/lib/__tests__/content-metadata.test.ts
@@ -41,6 +41,25 @@ describe("parseContentFile", () => {
     expect(Object.isFrozen(result.metadata.alternates)).toBe(true)
   })
 
+  it("parses static metadata when the ES2022 Object.hasOwn helper is unavailable", () => {
+    const descriptor = Object.getOwnPropertyDescriptor(Object, "hasOwn")
+    Object.defineProperty(Object, "hasOwn", { configurable: true, value: undefined })
+    let result: ReturnType<typeof parseContentFile>
+
+    try {
+      result = parseContentFile('export const metadata = { title: "Hello" }\n\n# Body\n', "docs/a.mdx")
+    } finally {
+      if (descriptor) Object.defineProperty(Object, "hasOwn", descriptor)
+    }
+
+    expect(result).toEqual({
+      body: "# Body\n",
+      metadata: { title: "Hello" },
+      metadataSource: "metadata-export",
+      editable: true,
+    })
+  })
+
   it("continues to parse YAML frontmatter", () => {
     const result = parseContentFile("---\ntitle: Hello\ntags:\n  - docs\n---\n\n# Body\n", "docs/a.md")
 

--- a/lib/__tests__/convex-action-boundaries.test.ts
+++ b/lib/__tests__/convex-action-boundaries.test.ts
@@ -698,6 +698,46 @@ describe("public Convex GitHub action boundaries", () => {
     })
   })
 
+  it("re-reads a Git-backed route placeholder so metadata-export titles can replace page", async () => {
+    const ctx = actionCtx()
+    authorizeEditor(ctx, [
+      {
+        _id: "document_1",
+        projectId: "project_1",
+        filePath: "article/page.mdx",
+        pathRepresentation: "content_relative_v1",
+        title: "page",
+        githubSha: "f".repeat(40),
+      },
+    ])
+    mockAuthorizedTitlePayload(
+      utf8ContentPayload(`export const metadata = {
+  title: "Free Printable Santa Letter Templates",
+}
+
+# Santa letters
+`),
+    )
+
+    await (syncTreeTitles as any).handler(ctx, {
+      projectId: "project_1",
+      readRef: BASE_SHA,
+      files: [{ path: "article/page.mdx", sha: "f".repeat(40) }],
+      githubToken: "editor-token",
+    })
+
+    expect(ctx.runMutation.mock.calls[1][1]).toEqual({
+      projectId: "project_1",
+      documents: [
+        {
+          filePath: "article/page.mdx",
+          title: "Free Printable Santa Letter Templates",
+          githubSha: "f".repeat(40),
+        },
+      ],
+    })
+  })
+
   it.each([
     [
       "a non-integer declared size",
@@ -1602,6 +1642,10 @@ describe("title sync batch persistence", () => {
       rows.push({ _id: id, ...value })
       return id
     })
+    const patch = vi.fn().mockImplementation(async (id, value) => {
+      const row = rows.find((candidate) => candidate._id === id)
+      if (row) Object.assign(row, value)
+    })
     const ctx = {
       db: {
         query: vi.fn().mockReturnValue({
@@ -1627,6 +1671,7 @@ describe("title sync batch persistence", () => {
           }),
         }),
         insert,
+        patch,
       },
     }
 
@@ -1652,6 +1697,52 @@ describe("title sync batch persistence", () => {
         pathRepresentation: "content_relative_v1",
         title: "Second",
         githubSha: "e".repeat(40),
+      }),
+    )
+  })
+
+  it("refreshes a Git-backed placeholder title without inserting a second document", async () => {
+    const found = {
+      _id: "document_1",
+      projectId: "project_1",
+      filePath: "article/page.mdx",
+      pathRepresentation: "content_relative_v1",
+      title: "page",
+      githubSha: "f".repeat(40),
+    }
+    const patch = vi.fn()
+    const insert = vi.fn()
+    const ctx = {
+      db: {
+        query: vi.fn().mockReturnValue({
+          withIndex: vi.fn().mockReturnValue({
+            filter: vi.fn().mockReturnValue({ first: vi.fn().mockResolvedValue(found) }),
+          }),
+        }),
+        insert,
+        patch,
+      },
+    }
+
+    const result = await (getOrCreateTitleSyncBatchInternal as any).handler(ctx, {
+      projectId: "project_1",
+      documents: [
+        {
+          filePath: "article/page.mdx",
+          title: "Free Printable Santa Letter Templates",
+          githubSha: "f".repeat(40),
+        },
+      ],
+    })
+
+    expect(result).toEqual({ inserted: 0, existing: 1 })
+    expect(insert).not.toHaveBeenCalled()
+    expect(patch).toHaveBeenCalledWith(
+      "document_1",
+      expect.objectContaining({
+        title: "Free Printable Santa Letter Templates",
+        githubSha: "f".repeat(40),
+        updatedAt: expect.any(Number),
       }),
     )
   })

--- a/lib/content-metadata.ts
+++ b/lib/content-metadata.ts
@@ -482,7 +482,7 @@ function staticValue(node: Expression, depth: number, budget: ParseBudget): unkn
         throw new Error("Metadata object exceeds limit")
       }
       const key = propertyKey(entry, budget)
-      if (Object.hasOwn(record, key)) throw new Error("Duplicate metadata key")
+      if (Object.getOwnPropertyDescriptor(record, key) !== undefined) throw new Error("Duplicate metadata key")
       Object.defineProperty(record, key, {
         value: staticValue(entry.value, depth + 1, budget),
         enumerable: true,


### PR DESCRIPTION
## Summary
- keep metadata parsing compatible with Convex's TypeScript target
- refresh Git-backed route placeholders so Explorer shows real MDX metadata titles
- prefer saved legacy drafts over canonical title-only placeholders during migration

## Production issue verified
- deployed the merged Convex functions to prestigious-orca-615
- synchronized REPOPRESS_CAPABILITY_SECRET from Vercel production to Convex without printing or persisting it
- confirmed the isolated sandbox cover is delivered as a blob URL and article rows now show real titles

## Verification
- 169 test files / 2,146 tests pass
- TypeScript clean
- Biome: 0 errors / 8 pre-existing warnings
- Convex production deploy typecheck and schema validation pass
