### PR TITLE
fix(studio): hydrate fresh saved draft revisions

### DIFF
--- a/components/studio/__tests__/document-hydration-key.test.ts
+++ b/components/studio/__tests__/document-hydration-key.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest"
+import { getDocumentHydrationKey } from "../studio-layout"
+
+describe("getDocumentHydrationKey", () => {
+  it("changes when a fresher Convex document revision arrives for the same file", () => {
+    const stale = getDocumentHydrationKey({ _id: "doc_1", updatedAt: 100, contentVersion: 1 }, "content/blog/page.mdx")
+    const fresh = getDocumentHydrationKey({ _id: "doc_1", updatedAt: 200, contentVersion: 2 }, "content/blog/page.mdx")
+
+    expect(fresh).not.toBe(stale)
+  })
+
+  it("is stable for repeat renders of the same revision", () => {
+    const document = { _id: "doc_1", updatedAt: 100, contentVersion: 1 }
+
+    expect(getDocumentHydrationKey(document, "content/blog/page.mdx")).toBe(
+      getDocumentHydrationKey(document, "content/blog/page.mdx"),
+    )
+  })
+})

--- a/components/studio/studio-layout.tsx
+++ b/components/studio/studio-layout.tsx
@@ -104,6 +104,14 @@ function inferTitleFromPath(path: string) {
   return fileName.replace(/\.(mdx?|markdown)$/i, "")
 }
 
+export function getDocumentHydrationKey(
+  document: { _id?: unknown; updatedAt?: unknown; contentVersion?: unknown } | null | undefined,
+  selectedPath: string | null | undefined,
+) {
+  if (!document || !selectedPath) return null
+  return `${selectedPath}:${String(document._id ?? "")}:${String(document.updatedAt ?? "")}:${String(document.contentVersion ?? "")}`
+}
+
 function freezePreviewData<T>(value: T): T {
   if (value === null || typeof value !== "object" || Object.isFrozen(value)) return value
   for (const key of Object.keys(value)) freezePreviewData(Object.getOwnPropertyDescriptor(value, key)?.value)
@@ -549,19 +557,20 @@ function StudioLayoutInner({
 
   const canMutateExplorer = Boolean(userId || projectAccessToken)
 
-  const hydratedForPath = React.useRef<string | null>(null)
+  const hydratedDocumentKey = React.useRef<string | null>(null)
 
   React.useEffect(() => {
     const selectedPath = selectedFile?.path ?? null
     if (!selectedPath) {
-      hydratedForPath.current = null
+      hydratedDocumentKey.current = null
       return
     }
-    if (!document || hydratedForPath.current === selectedPath) return
+    const hydrationKey = getDocumentHydrationKey(document, selectedPath)
+    if (!document || !hydrationKey || hydratedDocumentKey.current === hydrationKey) return
 
     const draftStatuses = new Set(["draft", "in_review", "approved"])
     if (draftStatuses.has(document.status) && hydrateFromDocument(document)) {
-      hydratedForPath.current = selectedPath
+      hydratedDocumentKey.current = hydrationKey
     }
   }, [document, selectedFile?.path, hydrateFromDocument])
 


### PR DESCRIPTION
## Summary
- key Studio draft hydration by document revision, not only file path
- allow a fresh Convex subscription result to replace stale cached query data after reload
- add regression coverage for stale-to-fresh revisions and stable repeat renders

## Verification
- 170 test files / 2,148 tests pass
- TypeScript passes
- Biome passes with 8 pre-existing warnings
- git diff --check passes

## Production E2E evidence
A frontmatter edit was saved successfully to the canonical Convex row (content version advanced), but reload rendered the older cached revision because the hydration guard had already marked the path complete. This patch lets the fresh updatedAt/contentVersion hydrate when it arrives.