### PR TITLE
fix(studio): preserve hydrated drafts after tree updates

### DIFF
--- a/components/studio/hooks/__tests__/use-studio-file-read-authority.test.tsx
+++ b/components/studio/hooks/__tests__/use-studio-file-read-authority.test.tsx
@@ -794,6 +794,30 @@ describe("useStudioFile immutable read authority", () => {
     expect(result.current.isDirty).toBe(true)
   })
 
+  it("does not replay the initial GitHub snapshot over a hydrated saved draft when the tree updates", async () => {
+    const initialFile = {
+      path: "content/guide.mdx",
+      sha: "f".repeat(40),
+      content: "---\ndescription: Remote description\n---\n# Remote body",
+    }
+    const { result, rerender } = renderHook(() => useStudioFile(initialFile, "content/guide.mdx"))
+
+    await waitFor(() => expect(result.current.frontmatter).toEqual({ description: "Remote description" }))
+    act(() => {
+      result.current.hydrateFromDocument({
+        body: "# Saved draft body",
+        frontmatter: { description: "Saved draft description" },
+      })
+    })
+    expect(result.current.frontmatter).toEqual({ description: "Saved draft description" })
+
+    studioContext.tree = [...studioContext.tree]
+    rerender()
+
+    expect(result.current.content).toBe("# Saved draft body")
+    expect(result.current.frontmatter).toEqual({ description: "Saved draft description" })
+  })
+
   it("resolves pathname popstate links relative to contentRoot while leaving query paths repository-relative", async () => {
     studioContext.tree = []
     const { result } = renderHook(() => useStudioFile(null, ""))

--- a/components/studio/hooks/use-studio-file.ts
+++ b/components/studio/hooks/use-studio-file.ts
@@ -92,6 +92,7 @@ export function useStudioFile(initialFile: InitialFile | null | undefined, curre
   const requestVersionRef = React.useRef(0)
   const remoteReadVersionRef = React.useRef<Map<string, number>>(new Map())
   const pendingDocumentHydrationRef = React.useRef<Map<string, PendingDocumentHydration>>(new Map())
+  const initialFileAppliedKeyRef = React.useRef<string | null>(null)
 
   const writeCachedSnapshot = React.useCallback((filePath: string, snapshot: CachedFileSnapshot) => {
     fileCacheRef.current.set(filePath, snapshot)
@@ -465,10 +466,14 @@ export function useStudioFile(initialFile: InitialFile | null | undefined, curre
 
   React.useEffect(() => {
     if (initialFile) {
-      const snapshot = parseFileSnapshot(initialFile.content, initialFile.sha, initialFile.path)
-      writeCachedSnapshot(initialFile.path, snapshot)
-      applySnapshot(initialFile.path, snapshot)
-      syncBrowserUrl(initialFile.path, "replace")
+      const initialFileKey = `${initialFile.path}:${initialFile.sha}`
+      if (initialFileAppliedKeyRef.current !== initialFileKey) {
+        initialFileAppliedKeyRef.current = initialFileKey
+        const snapshot = parseFileSnapshot(initialFile.content, initialFile.sha, initialFile.path)
+        writeCachedSnapshot(initialFile.path, snapshot)
+        applySnapshot(initialFile.path, snapshot)
+        syncBrowserUrl(initialFile.path, "replace")
+      }
       return
     }
 


### PR DESCRIPTION
## Summary
- apply the server-provided initial GitHub snapshot once per immutable path/SHA
- prevent later tree/callback updates from replaying remote bytes over a hydrated Convex draft
- add a behavioral regression that hydrates a saved frontmatter/body draft, rerenders after a tree update, and asserts the draft survives

## Verification
- 170 test files / 2,149 tests pass
- TypeScript passes
- Biome passes with 8 pre-existing warnings
- git diff --check passes

## Production E2E evidence
The production Convex row contains the saved marker, and the fresh revision now hydrates after PR #61. A later tree update then reapplies the immutable initialFile snapshot and restores the GitHub frontmatter. This patch removes that second overwrite race.