### PR TITLE
chore(studio): expose hydration state for e2e

### DIFF
--- a/components/studio/studio-layout.tsx
+++ b/components/studio/studio-layout.tsx
@@ -489,6 +489,7 @@ function StudioLayoutInner({
     content,
     frontmatter,
     sha,
+    isDirty,
     isFileLoading,
     sourceAuthority,
     isSourceEditable,
@@ -1395,6 +1396,15 @@ function StudioLayoutInner({
         className="h-full w-full flex flex-col overflow-hidden bg-studio-canvas text-studio-fg"
         role="application"
         aria-label="RepoPress Studio"
+        data-studio-source-authority={sourceAuthority}
+        data-studio-editor-dirty={isDirty ? "true" : "false"}
+        data-studio-draft-available={
+          document && (typeof document.body === "string" || document.frontmatter !== undefined) ? "true" : "false"
+        }
+        data-studio-draft-version={document?.contentVersion ?? "none"}
+        data-studio-draft-hydrated={
+          hydratedDocumentKey.current === getDocumentHydrationKey(document, selectedFile?.path) ? "true" : "false"
+        }
       >
         <div aria-live="polite" aria-atomic="true" className="sr-only">
           {document ? `Editing ${selectedFile?.name || "file"}, status: ${currentStatus}` : "No file selected"}


### PR DESCRIPTION
## Summary
- expose non-secret Studio root data attributes for source authority, local dirty state, draft availability/version, and hydration completion
- make production browser E2E able to distinguish skipped hydration from a later overwrite without logging content or credentials

## Verification
- TypeScript passes
- Biome passes with 8 pre-existing warnings
- git diff --check passes
- prior main head is green at 170 files / 2,149 tests