### PR TITLE
fix(studio): ignore no-op editor initialization

### DIFF
--- a/components/studio/hooks/__tests__/use-studio-file-read-authority.test.tsx
+++ b/components/studio/hooks/__tests__/use-studio-file-read-authority.test.tsx
@@ -818,6 +818,23 @@ describe("useStudioFile immutable read authority", () => {
     expect(result.current.frontmatter).toEqual({ description: "Saved draft description" })
   })
 
+  it("does not mark editor initialization callbacks dirty when content and frontmatter are unchanged", async () => {
+    const initialFile = {
+      path: "content/guide.mdx",
+      sha: "f".repeat(40),
+      content: "---\ndescription: Remote description\n---\n# Remote body",
+    }
+    const { result } = renderHook(() => useStudioFile(initialFile, "content/guide.mdx"))
+
+    act(() => {
+      result.current.setContent("# Remote body")
+      result.current.setFrontmatterKey("description", "Remote description")
+      result.current.setFrontmatter({ description: "Remote description" })
+    })
+
+    expect(result.current.isDirty).toBe(false)
+  })
+
   it("resolves pathname popstate links relative to contentRoot while leaving query paths repository-relative", async () => {
     studioContext.tree = []
     const { result } = renderHook(() => useStudioFile(null, ""))

--- a/components/studio/hooks/use-studio-file.ts
+++ b/components/studio/hooks/use-studio-file.ts
@@ -46,6 +46,32 @@ interface PendingDocumentHydration {
 
 export type SourceAuthority = "unknown" | "editable" | "read-only"
 
+function areFrontmatterValuesEqual(left: unknown, right: unknown): boolean {
+  if (Object.is(left, right)) return true
+  if (Array.isArray(left) || Array.isArray(right)) {
+    return (
+      Array.isArray(left) &&
+      Array.isArray(right) &&
+      left.length === right.length &&
+      left.every((value, index) => areFrontmatterValuesEqual(value, right[index]))
+    )
+  }
+  if (!left || !right || typeof left !== "object" || typeof right !== "object") return false
+
+  const leftRecord = left as Record<string, unknown>
+  const rightRecord = right as Record<string, unknown>
+  const leftKeys = Object.keys(leftRecord)
+  const rightKeys = Object.keys(rightRecord)
+  return (
+    leftKeys.length === rightKeys.length &&
+    leftKeys.every(
+      (key) =>
+        Object.getOwnPropertyDescriptor(rightRecord, key) !== undefined &&
+        areFrontmatterValuesEqual(leftRecord[key], rightRecord[key]),
+    )
+  )
+}
+
 function parseFileSnapshot(rawContent: string, sha: string | null, filePath: string): CachedFileSnapshot {
   const parsed = parseContentFile(rawContent, filePath)
   return {
@@ -710,6 +736,8 @@ export function useStudioFile(initialFile: InitialFile | null | undefined, curre
   const handleContentChange = React.useCallback(
     (newContent: string) => {
       if (!isSourceEditable) return
+      const activeContent = selectedFile?.path ? fileCacheRef.current.get(selectedFile.path)?.content : content
+      if (newContent === activeContent) return
       setContent(newContent)
       setIsDirty(true)
       if (selectedFile?.path) {
@@ -723,12 +751,25 @@ export function useStudioFile(initialFile: InitialFile | null | undefined, curre
         })
       }
     },
-    [selectedFile?.path, frontmatter, sha, isSourceEditable, sourceAuthority, sourceDiagnostic, writeCachedSnapshot],
+    [
+      selectedFile?.path,
+      content,
+      frontmatter,
+      sha,
+      isSourceEditable,
+      sourceAuthority,
+      sourceDiagnostic,
+      writeCachedSnapshot,
+    ],
   )
 
   const handleFrontmatterChangeKey = React.useCallback(
     (key: string, value: unknown) => {
       if (!isSourceEditable) return
+      const activeFrontmatter = selectedFile?.path
+        ? (fileCacheRef.current.get(selectedFile.path)?.frontmatter ?? frontmatter)
+        : frontmatter
+      if (areFrontmatterValuesEqual(activeFrontmatter[key], value)) return
       setFrontmatter((prev) => {
         const next = { ...prev, [key]: value }
         if (selectedFile?.path) {
@@ -745,12 +786,25 @@ export function useStudioFile(initialFile: InitialFile | null | undefined, curre
       })
       setIsDirty(true)
     },
-    [selectedFile?.path, content, sha, isSourceEditable, sourceAuthority, sourceDiagnostic, writeCachedSnapshot],
+    [
+      selectedFile?.path,
+      content,
+      frontmatter,
+      sha,
+      isSourceEditable,
+      sourceAuthority,
+      sourceDiagnostic,
+      writeCachedSnapshot,
+    ],
   )
 
   const handleFrontmatterChangeAll = React.useCallback(
     (nextFrontmatter: Record<string, unknown>) => {
       if (!isSourceEditable) return
+      const activeFrontmatter = selectedFile?.path
+        ? (fileCacheRef.current.get(selectedFile.path)?.frontmatter ?? frontmatter)
+        : frontmatter
+      if (areFrontmatterValuesEqual(activeFrontmatter, nextFrontmatter)) return
       setFrontmatter(nextFrontmatter)
       setIsDirty(true)
       if (selectedFile?.path) {
@@ -764,7 +818,16 @@ export function useStudioFile(initialFile: InitialFile | null | undefined, curre
         })
       }
     },
-    [selectedFile?.path, content, sha, isSourceEditable, sourceAuthority, sourceDiagnostic, writeCachedSnapshot],
+    [
+      selectedFile?.path,
+      content,
+      frontmatter,
+      sha,
+      isSourceEditable,
+      sourceAuthority,
+      sourceDiagnostic,
+      writeCachedSnapshot,
+    ],
   )
 
   const navigateToFile = React.useCallback(


### PR DESCRIPTION
## Summary
- treat identical MDXEditor initialization callbacks as no-ops instead of local edits
- compare content against the live file snapshot and frontmatter structurally before setting dirty state
- preserve rapid sequential edits by reading the synchronously updated file cache
- add a regression proving identical body, field, and full-frontmatter callbacks keep the editor clean

## Verification
- 170 test files / 2,150 tests pass
- TypeScript passes
- Biome passes with 8 pre-existing warnings
- git diff --check passes

## Production E2E evidence
The Studio root reports sourceAuthority=editable, draftAvailable=true, draftVersion=6, and draftHydrated=true, but editorDirty=true before the draft arrives. MDXEditor emits its initial markdown through onChange; the hook treated the byte-identical value as a user edit, so hydrateFromDocument correctly preserved the wrong local baseline. The new idempotent handlers remove that false dirty state.